### PR TITLE
[JDBC 라이브러리 구현하기 - 1, 2단계] 케빈(박진홍) 미션 제출합니다. 

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -3,19 +3,12 @@ package com.techcourse.dao;
 import com.techcourse.domain.User;
 import nextstep.jdbc.JdbcTemplate;
 import nextstep.jdbc.RowMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.List;
 
 public class UserDao {
 
-    private static final RowMapper<User> ROW_MAPPER = (resultSet, rowNum) -> {
+    private static final RowMapper<User> ROW_MAPPER = (resultSet) -> {
         long id = resultSet.getLong("id");
         String account = resultSet.getString("account");
         String password = resultSet.getString("password");
@@ -36,8 +29,7 @@ public class UserDao {
 
     public void update(User user) {
         final String sql = "update users set account = ?, password = ?, email = ? where id = ?";
-        jdbcTemplate
-            .update(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
+        jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
     }
 
     public List<User> findAll() {

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -1,6 +1,8 @@
 package com.techcourse.dao;
 
 import com.techcourse.domain.User;
+import nextstep.jdbc.JdbcTemplate;
+import nextstep.jdbc.RowMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,104 +15,43 @@ import java.util.List;
 
 public class UserDao {
 
-    private static final Logger log = LoggerFactory.getLogger(UserDao.class);
+    private static final RowMapper<User> ROW_MAPPER = (resultSet, rowNum) -> {
+        long id = resultSet.getLong("id");
+        String account = resultSet.getString("account");
+        String password = resultSet.getString("password");
+        String email = resultSet.getString("email");
+        return new User(id, account, password, email);
+    };
 
-    private final DataSource dataSource;
+    private final JdbcTemplate jdbcTemplate;
 
-    public UserDao(DataSource dataSource) {
-        this.dataSource = dataSource;
+    public UserDao(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public void insert(User user) {
         final String sql = "insert into users (account, password, email) values (?, ?, ?)";
-
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
-
-            log.debug("query : {}", sql);
-
-            pstmt.setString(1, user.getAccount());
-            pstmt.setString(2, user.getPassword());
-            pstmt.setString(3, user.getEmail());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+        jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail());
     }
 
     public void update(User user) {
-        // todo
+        final String sql = "update users set account = ?, password = ?, email = ? where id = ?";
+        jdbcTemplate
+            .update(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
     }
 
     public List<User> findAll() {
-        // todo
-        return null;
+        final String sql = "select * from users";
+        return jdbcTemplate.queryForList(sql, ROW_MAPPER);
     }
 
     public User findById(Long id) {
         final String sql = "select id, account, password, email from users where id = ?";
-
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
-            pstmt.setLong(1, id);
-            rs = pstmt.executeQuery();
-
-            log.debug("query : {}", sql);
-
-            if (rs.next()) {
-                return new User(
-                        rs.getLong(1),
-                        rs.getString(2),
-                        rs.getString(3),
-                        rs.getString(4));
-            }
-            return null;
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (rs != null) {
-                    rs.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+        return jdbcTemplate.queryForObject(sql, ROW_MAPPER, id);
     }
 
     public User findByAccount(String account) {
-        // todo
-        return null;
+        final String sql = "select id, account, password, email from users where account = ?";
+        return jdbcTemplate.queryForObject(sql, ROW_MAPPER, account);
     }
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -3,6 +3,11 @@ package com.techcourse.dao;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import nextstep.jdbc.JdbcTemplate;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,9 +23,18 @@ class UserDaoTest {
     void setup() {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
 
-        userDao = new UserDao(DataSourceConfig.getInstance());
+        userDao = new UserDao(new JdbcTemplate(DataSourceConfig.getInstance()));
         final User user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        String sql = "drop table users";
+        try (Connection connection = DataSourceConfig.getInstance().getConnection();
+            PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.execute();
+        }
     }
 
     @Test

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-jre'
 
     implementation 'org.reflections:reflections:0.9.11'
+    implementation 'com.h2database:h2:1.4.200'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.3'
     testImplementation 'org.mockito:mockito-core:3.12.3'

--- a/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -6,6 +6,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.sql.DataSource;
 import nextstep.jdbc.exception.DataAccessException;
 import nextstep.jdbc.exception.EmptyResultDataException;
@@ -39,7 +40,7 @@ public class JdbcTemplate {
             ResultSet rs = pstmt.executeQuery()) {
             List<T> list = new ArrayList<>();
             while (rs.next()) {
-                list.add(rowMapper.mapRow(rs, rs.getRow()));
+                list.add(rowMapper.mapRow(rs));
             }
             return list;
         } catch (SQLException sqlException) {
@@ -64,9 +65,10 @@ public class JdbcTemplate {
         Connection connection,
         Object... args
     ) throws SQLException {
+        Objects.requireNonNull(args);
         PreparedStatement preparedStatement = connection.prepareStatement(sql);
         for (int i = 0; i < args.length; i++) {
-            preparedStatement.setString(i + 1, String.valueOf(args[i]));
+            preparedStatement.setObject(i + 1, args[i]);
         }
         return preparedStatement;
     }
@@ -78,7 +80,7 @@ public class JdbcTemplate {
         if (!resultSet.next()) {
             throw new EmptyResultDataException();
         }
-        T target = rowMapper.mapRow(resultSet, resultSet.getRow());
+        T target = rowMapper.mapRow(resultSet);
         if (resultSet.next()) {
             throw new IncorrectResultSizeDataAccessException();
         }

--- a/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -33,9 +33,9 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> List<T> queryForList(String sql, RowMapper<T> rowMapper) {
+    public <T> List<T> queryForList(String sql, RowMapper<T> rowMapper, Object... args) {
         try (Connection conn = dataSource.getConnection();
-            PreparedStatement pstmt = conn.prepareStatement(sql);
+            PreparedStatement pstmt = generatePreparedStatement(sql, conn, args);
             ResultSet rs = pstmt.executeQuery()) {
             List<T> list = new ArrayList<>();
             while (rs.next()) {

--- a/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -1,9 +1,87 @@
 package nextstep.jdbc;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import nextstep.jdbc.exception.DataAccessException;
+import nextstep.jdbc.exception.EmptyResultDataException;
+import nextstep.jdbc.exception.IncorrectResultSizeDataAccessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
+
+    private final DataSource dataSource;
+
+    public JdbcTemplate(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public int update(String sql, Object... args) {
+        try (Connection conn = dataSource.getConnection();
+            PreparedStatement pstmt = generatePreparedStatement(sql, conn, args)) {
+            return pstmt.executeUpdate();
+        } catch (SQLException sqlException) {
+            log.error(sqlException.getMessage(), sqlException);
+            throw new DataAccessException(sqlException);
+        }
+    }
+
+    public <T> List<T> queryForList(String sql, RowMapper<T> rowMapper) {
+        try (Connection conn = dataSource.getConnection();
+            PreparedStatement pstmt = conn.prepareStatement(sql);
+            ResultSet rs = pstmt.executeQuery()) {
+            List<T> list = new ArrayList<>();
+            while (rs.next()) {
+                list.add(rowMapper.mapRow(rs, rs.getRow()));
+            }
+            return list;
+        } catch (SQLException sqlException) {
+            log.error(sqlException.getMessage(), sqlException);
+            throw new DataAccessException(sqlException);
+        }
+    }
+
+    public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... args) {
+        try (Connection conn = dataSource.getConnection();
+            PreparedStatement pstmt = generatePreparedStatement(sql, conn, args);
+            ResultSet rs = pstmt.executeQuery()) {
+            return requiredSingleResult(rowMapper, rs);
+        } catch (SQLException sqlException) {
+            log.error(sqlException.getMessage(), sqlException);
+            throw new DataAccessException(sqlException);
+        }
+    }
+
+    private PreparedStatement generatePreparedStatement(
+        String sql,
+        Connection connection,
+        Object... args
+    ) throws SQLException {
+        PreparedStatement preparedStatement = connection.prepareStatement(sql);
+        for (int i = 0; i < args.length; i++) {
+            preparedStatement.setString(i + 1, (String) args[i]);
+        }
+        return preparedStatement;
+    }
+
+    private <T> T requiredSingleResult(
+        RowMapper<T> rowMapper,
+        ResultSet resultSet
+    ) throws SQLException {
+        if (!resultSet.next()) {
+            throw new EmptyResultDataException();
+        }
+        T target = rowMapper.mapRow(resultSet, resultSet.getRow());
+        if (resultSet.next()) {
+            throw new IncorrectResultSizeDataAccessException();
+        }
+        return target;
+    }
 }

--- a/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -66,7 +66,7 @@ public class JdbcTemplate {
     ) throws SQLException {
         PreparedStatement preparedStatement = connection.prepareStatement(sql);
         for (int i = 0; i < args.length; i++) {
-            preparedStatement.setString(i + 1, (String) args[i]);
+            preparedStatement.setString(i + 1, String.valueOf(args[i]));
         }
         return preparedStatement;
     }

--- a/jdbc/src/main/java/nextstep/jdbc/RowMapper.java
+++ b/jdbc/src/main/java/nextstep/jdbc/RowMapper.java
@@ -6,5 +6,5 @@ import java.sql.SQLException;
 @FunctionalInterface
 public interface RowMapper<T> {
 
-    T mapRow(ResultSet resultSet, int rowNum) throws SQLException;
+    T mapRow(ResultSet resultSet) throws SQLException;
 }

--- a/jdbc/src/main/java/nextstep/jdbc/RowMapper.java
+++ b/jdbc/src/main/java/nextstep/jdbc/RowMapper.java
@@ -1,0 +1,10 @@
+package nextstep.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface RowMapper<T> {
+
+    T mapRow(ResultSet resultSet, int rowNum) throws SQLException;
+}

--- a/jdbc/src/main/java/nextstep/jdbc/exception/DataAccessException.java
+++ b/jdbc/src/main/java/nextstep/jdbc/exception/DataAccessException.java
@@ -1,0 +1,14 @@
+package nextstep.jdbc.exception;
+
+import java.sql.SQLException;
+
+public class DataAccessException extends RuntimeException {
+
+    public DataAccessException(String message) {
+        super(message);
+    }
+
+    public DataAccessException(SQLException sqlException) {
+        super(sqlException);
+    }
+}

--- a/jdbc/src/main/java/nextstep/jdbc/exception/EmptyResultDataException.java
+++ b/jdbc/src/main/java/nextstep/jdbc/exception/EmptyResultDataException.java
@@ -1,0 +1,15 @@
+package nextstep.jdbc.exception;
+
+import java.sql.SQLException;
+import nextstep.jdbc.exception.DataAccessException;
+
+public class EmptyResultDataException extends DataAccessException {
+
+    public EmptyResultDataException() {
+        super("Expected single data, but it was empty result!");
+    }
+
+    public EmptyResultDataException(SQLException sqlException) {
+        super(sqlException);
+    }
+}

--- a/jdbc/src/main/java/nextstep/jdbc/exception/IncorrectResultSizeDataAccessException.java
+++ b/jdbc/src/main/java/nextstep/jdbc/exception/IncorrectResultSizeDataAccessException.java
@@ -1,0 +1,10 @@
+package nextstep.jdbc.exception;
+
+import nextstep.jdbc.exception.DataAccessException;
+
+public class IncorrectResultSizeDataAccessException extends DataAccessException {
+
+    public IncorrectResultSizeDataAccessException() {
+        super("Expected single data, but it was more than one result!");
+    }
+}

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -1,5 +1,217 @@
 package nextstep.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import nextstep.jdbc.exception.EmptyResultDataException;
+import nextstep.jdbc.exception.IncorrectResultSizeDataAccessException;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("JdbcTemplate 단위 테스트")
 class JdbcTemplateTest {
 
+    private static final JdbcDataSource JDBC_DATA_SOURCE = new JdbcDataSource();
+    private static final RowMapper<User> ROW_MAPPER = (resultSet, rowNum) -> {
+        long id = resultSet.getLong("id");
+        String account = resultSet.getString("account");
+        String password = resultSet.getString("password");
+        String email = resultSet.getString("email");
+        return new User(id, account, password, email);
+    };
+
+    static {
+        JDBC_DATA_SOURCE.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;");
+        JDBC_DATA_SOURCE.setUser("");
+        JDBC_DATA_SOURCE.setPassword("");
+    }
+
+    private final JdbcTemplate jdbcTemplate = new JdbcTemplate(JDBC_DATA_SOURCE);
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        String schema = "create table if not exists users (\n"
+            + "    id bigint auto_increment,\n"
+            + "    account varchar(100) not null,\n"
+            + "    password varchar(100) not null,\n"
+            + "    email varchar(100) not null,\n"
+            + "    primary key(id)\n"
+            + ");\n";
+        try (Connection connection = JDBC_DATA_SOURCE.getConnection();
+            PreparedStatement preparedStatement = connection.prepareStatement(schema)) {
+            preparedStatement.execute();
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        String sql = "drop table users";
+        try (Connection connection = JDBC_DATA_SOURCE.getConnection();
+            PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.execute();
+        }
+    }
+
+    @DisplayName("update 메서드로 데이터를 저장하며, queryForObject로 조회한다.")
+    @Test
+    void update_and_queryForObject() {
+        // given
+        String insertQuery = "insert into users(account, password, email) values(?, ?, ?);";
+        String selectQuery = "select * from users where account = ?";
+
+        // when
+        int rowCounts = jdbcTemplate.update(insertQuery, "gugu", "123", "woowa@naver.com");
+        User user = jdbcTemplate.queryForObject(selectQuery, ROW_MAPPER, "gugu");
+
+        // then
+        assertThat(rowCounts).isOne();
+        assertThat(user.getId()).isNotNull();
+        assertThat(user).usingRecursiveComparison()
+            .ignoringFields("id")
+            .isEqualTo(new User("gugu", "123", "woowa@naver.com"));
+    }
+
+    @DisplayName("update 메서드로 수정하면 영향 받은 ROW 개수가 반환되며, queryForList로 조회한다.")
+    @Test
+    void update_and_queryForList() {
+        // given
+        String insertQuery = "insert into users(account, password, email) values(?, ?, ?);";
+        jdbcTemplate.update(insertQuery, "gugu", "123", "woowa@naver.com");
+        jdbcTemplate.update(insertQuery, "gugu2", "1234", "woowa2@naver.com");
+        jdbcTemplate.update(insertQuery, "gugu3", "1234", "woowa3@naver.com");
+
+        // when
+        String sql = "update users set account = ? where password = ?";
+        String selectQuery = "select * from users";
+        int rowCounts = jdbcTemplate.update(sql, "kevin", "1234");
+        List<User> users = jdbcTemplate.queryForList(selectQuery, ROW_MAPPER);
+
+        // then
+        assertThat(rowCounts).isEqualTo(2);
+        assertThat(users).extracting("account")
+            .contains("gugu", "kevin", "kevin");
+    }
+
+    @DisplayName("queryForList 메서드는 해당 데이터가 없는 경우 빈 리스트를 반환한다.")
+    @Test
+    void queryForList_empty() {
+        // given
+        String query = "select * from users";
+
+        // when
+        List<User> users = jdbcTemplate.queryForList(query, ROW_MAPPER);
+
+        // then
+        assertThat(users).isEmpty();
+    }
+
+    @DisplayName("queryForObject 메서드는")
+    @Nested
+    class Describe_queryForObject {
+
+        @DisplayName("결과값이 0개일 때")
+        @Nested
+        class Context_result_size_empty {
+
+            @DisplayName("EmptyResultDataException이 발생한다.")
+            @Test
+            void it_throws_EmptyResultDataException() {
+                // given
+                String sql = "select * from users where id = ?";
+
+                // when, then
+                assertThatCode(() -> jdbcTemplate.queryForObject(sql, ROW_MAPPER, "13121"))
+                    .isInstanceOf(EmptyResultDataException.class)
+                    .hasMessage("Expected single data, but it was empty result!");
+            }
+        }
+
+        @DisplayName("결과값이 1개일 때")
+        @Nested
+        class Context_result_size_single {
+
+            @DisplayName("정상적으로 데이터가 반환된다.")
+            @Test
+            void it_returns_target() {
+                // given
+                String insertQuery = "insert into users(account, password, email) values(?, ?, ?);";
+                jdbcTemplate.update(insertQuery, "gugu", "123", "woowa@naver.com");
+                String sql = "select * from users where account = ?";
+
+                // when
+                User user = jdbcTemplate.queryForObject(sql, ROW_MAPPER, "gugu");
+
+                // then
+                assertThat(user.getId()).isNotNull();
+                assertThat(user).usingRecursiveComparison()
+                    .ignoringFields("id")
+                    .isEqualTo(new User("gugu", "123", "woowa@naver.com"));
+            }
+        }
+
+        @DisplayName("결과값이 2개 이상일 때")
+        @Nested
+        class Context_result_size_more_than_two {
+
+            @DisplayName("IncorrectResultSizeDataAccessException 예외가 발생한다.")
+            @Test
+            void it_throws_IncorrectResultSizeDataAccessException() {
+                // given
+                String insertQuery = "insert into users(account, password, email) values(?, ?, ?);";
+                jdbcTemplate.update(insertQuery, "gugu", "123", "woowa@naver.com");
+                jdbcTemplate.update(insertQuery, "gugu2", "123", "woowa2@naver.com");
+                String sql = "select * from users where password = ?";
+
+                // when, then
+                assertThatCode(() -> jdbcTemplate.queryForObject(sql, ROW_MAPPER, "123"))
+                    .isInstanceOf(IncorrectResultSizeDataAccessException.class)
+                    .hasMessage("Expected single data, but it was more than one result!");
+            }
+        }
+    }
+
+    private static class User {
+
+        private Long id;
+        private final String account;
+        private String password;
+        private final String email;
+
+        public User(long id, String account, String password, String email) {
+            this.id = id;
+            this.account = account;
+            this.password = password;
+            this.email = email;
+        }
+
+        public User(String account, String password, String email) {
+            this.account = account;
+            this.password = password;
+            this.email = email;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getAccount() {
+            return account;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+    }
 }

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 class JdbcTemplateTest {
 
     private static final JdbcDataSource JDBC_DATA_SOURCE = new JdbcDataSource();
-    private static final RowMapper<User> ROW_MAPPER = (resultSet, rowNum) -> {
+    private static final RowMapper<User> ROW_MAPPER = (resultSet) -> {
         long id = resultSet.getLong("id");
         String account = resultSet.getString("account");
         String password = resultSet.getString("password");


### PR DESCRIPTION
안녕하세요 잘부탁드립니다!
예전에 토비의 스프링 스터디를 진행하면서 비슷한 내용을 학습한 경험이 있는데, 덕분에 조금 수월하게 구현할 수 있었습니다.

---

구현하면서 궁금점이 생겼는데요. 

```
@Override
@Nullable
public <T> T queryForObject(String sql, RowMapper<T> rowMapper) throws DataAccessException {
	List<T> results = query(sql, rowMapper);
	return DataAccessUtils.nullableSingleResult(results);
}
```

실제 JdbcTemplate의 경우 단건 조회할 때에도 내부적으로 리스트 조회 메서드를 실행한 다음, 해당 컬렉션의 크기를 비교해서 실제 결과가 단건만 존재하는지 검사합니다.

제 개인적인 생각으로는 코드는 깔끔하게 줄어들 수 있어도, 약간(?)은 비효율적인 방식이라고 생각되는데요.

예를 들어, 데이터 조회 결과가 1만건이라면 반복문을 순회하면서 mapRow로 1만개의 인스턴스를 만들고나서야 단건인지 검사하게 될텐데요.
불필요한 객체 생성 및 반복문 순회 필요 없이 2번만 ``next``를 호출하여 단건 조회인지 검증하도록 코드를 작성했습니다.

코기의 생각은 어떤지 궁금합니다~