### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 오찌(오지훈) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -3,6 +3,7 @@ package com.techcourse.dao;
 import com.techcourse.domain.User;
 import java.util.List;
 import javax.sql.DataSource;
+import nextstep.jdbc.BeanPropertyRowMapper;
 import nextstep.jdbc.JdbcTemplate;
 import nextstep.jdbc.RowMapper;
 import org.slf4j.Logger;
@@ -11,12 +12,8 @@ import org.slf4j.LoggerFactory;
 public class UserDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserDao.class);
-    private static final RowMapper<User> USER_ROW_MAPPER = (rs, rowNum) -> new User(
-            rs.getLong("id"),
-            rs.getString("account"),
-            rs.getString("password"),
-            rs.getString("email")
-    );
+
+    private static final RowMapper<User> USER_BEAN_ROW_MAPPER = new BeanPropertyRowMapper<>(User.class);
 
     private final JdbcTemplate jdbcTemplate;
 
@@ -43,18 +40,18 @@ public class UserDao {
     public List<User> findAll() {
         String sql = "SELECT id, account, password, email FROM users";
 
-        return jdbcTemplate.query(sql, USER_ROW_MAPPER);
+        return jdbcTemplate.query(sql, USER_BEAN_ROW_MAPPER);
     }
 
     public User findById(final Long id) {
         String sql = "SELECT id, account, password, email FROM users WHERE id = ?";
 
-        return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, id);
+        return jdbcTemplate.queryForObject(sql, USER_BEAN_ROW_MAPPER, id);
     }
 
     public User findByAccount(final String account) {
         String sql = "SELECT id, account, password, email FROM users WHERE account = ?";
 
-        return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, account);
+        return jdbcTemplate.queryForObject(sql, USER_BEAN_ROW_MAPPER, account);
     }
 }

--- a/app/src/main/java/com/techcourse/domain/User.java
+++ b/app/src/main/java/com/techcourse/domain/User.java
@@ -20,6 +20,11 @@ public class User {
         this.email = email;
     }
 
+    public User() {
+        this.account = null;
+        this.email = null;
+    }
+
     public boolean checkPassword(String password) {
         return this.password.equals(password);
     }

--- a/app/src/main/java/com/techcourse/domain/User.java
+++ b/app/src/main/java/com/techcourse/domain/User.java
@@ -20,7 +20,7 @@ public class User {
         this.email = email;
     }
 
-    public User() {
+    private User() {
         this.account = null;
         this.email = null;
     }

--- a/jdbc/src/main/java/nextstep/jdbc/BeanPropertyRowMapper.java
+++ b/jdbc/src/main/java/nextstep/jdbc/BeanPropertyRowMapper.java
@@ -1,0 +1,56 @@
+package nextstep.jdbc;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class BeanPropertyRowMapper<T> implements RowMapper<T> {
+
+    private final Class<T> type;
+    private final Field[] fields;
+
+    public BeanPropertyRowMapper(final Class<T> type) {
+        this.type = type;
+        fields = type.getDeclaredFields();
+    }
+
+    @Override
+    public T mapRow(final ResultSet rs, final int rowNum) throws SQLException {
+        T instance = instantiate();
+        for (Field field : fields) {
+            field.setAccessible(true);
+            Class<?> fieldType = field.getType();
+            String fieldName = field.getName();
+            Object fieldValue = rs.getObject(fieldName, fieldType);
+            setField(instance, field, fieldValue);
+        }
+        return instance;
+    }
+
+    private T instantiate() {
+        try {
+            Constructor<T> primaryConstructor = getPrimaryConstructor();
+            return primaryConstructor.newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Constructor<T> getPrimaryConstructor() {
+        try {
+            return type.getConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("BeanPropertyRowMapper needs a primary constructor!", e);
+        }
+    }
+
+    private void setField(final T instance, final Field field, final Object fieldValue) throws SQLException {
+        try {
+            field.set(instance, fieldValue);
+        } catch (IllegalAccessException e) {
+            throw new SQLException(e);
+        }
+    }
+}

--- a/jdbc/src/main/java/nextstep/jdbc/BeanPropertyRowMapper.java
+++ b/jdbc/src/main/java/nextstep/jdbc/BeanPropertyRowMapper.java
@@ -32,6 +32,7 @@ public class BeanPropertyRowMapper<T> implements RowMapper<T> {
     private T instantiate() {
         try {
             Constructor<T> primaryConstructor = getPrimaryConstructor();
+            primaryConstructor.setAccessible(true);
             return primaryConstructor.newInstance();
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
@@ -40,7 +41,7 @@ public class BeanPropertyRowMapper<T> implements RowMapper<T> {
 
     private Constructor<T> getPrimaryConstructor() {
         try {
-            return type.getConstructor();
+            return type.getDeclaredConstructor();
         } catch (NoSuchMethodException e) {
             throw new RuntimeException("BeanPropertyRowMapper needs a primary constructor!", e);
         }

--- a/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -26,10 +26,11 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> query(final String sql, RowMapper<T> rowMapper, Object... args) {
-        return executeQuery(sql, pstmt -> query(pstmt, rowMapper), args);
+        return executeQuery(sql, pstmt -> executeAndReturnResults(pstmt, rowMapper), args);
     }
 
-    private static <T> List<T> query(final PreparedStatement pstmt, final RowMapper<T> rowMapper) throws SQLException {
+    private static <T> List<T> executeAndReturnResults(final PreparedStatement pstmt, final RowMapper<T> rowMapper)
+            throws SQLException {
         try (ResultSet rs = pstmt.executeQuery()) {
             return DataAccessUtils.getResults(rowMapper, rs);
         }

--- a/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -1,8 +1,5 @@
 package nextstep.jdbc;
 
-import static java.sql.ResultSet.CONCUR_READ_ONLY;
-import static java.sql.ResultSet.TYPE_SCROLL_INSENSITIVE;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -39,34 +36,17 @@ public class JdbcTemplate {
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
             StatementUtils.setArguments(pstmt, args);
-            return executeQuery(rowMapper, pstmt);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                return DataAccessUtils.mapResultSetToList(rowMapper, rs);
+            }
         } catch (SQLException e) {
             log.debug("ERROR CODE: {} SQL STATE: {}", e.getErrorCode(), e.getSQLState());
             throw new DataAccessException(e);
         }
     }
 
-    private static <T> List<T> executeQuery(RowMapper<T> rowMapper, PreparedStatement pstmt) throws SQLException {
-        try (ResultSet rs = pstmt.executeQuery()) {
-            return DataAccessUtils.mapResultSetToList(rowMapper, rs);
-        }
-    }
-
-    public <T> T queryForObject(final String sql, RowMapper<T> rowMapper, Object... args) {
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql, TYPE_SCROLL_INSENSITIVE, CONCUR_READ_ONLY)) {
-            StatementUtils.setArguments(pstmt, args);
-            return executeQueryForObject(rowMapper, pstmt);
-        } catch (SQLException e) {
-            log.debug("ERROR CODE: {} SQL STATE: {}", e.getErrorCode(), e.getSQLState());
-            throw new DataAccessException(e);
-        }
-    }
-
-    private static <T> T executeQueryForObject(RowMapper<T> rowMapper, PreparedStatement pstmt) throws SQLException {
-        try (ResultSet rs = pstmt.executeQuery()) {
-            DataAccessUtils.validateResultSetSize(rs);
-            return DataAccessUtils.mapResultSetToObject(rowMapper, rs);
-        }
+    public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
+        List<T> result = query(sql, rowMapper, args);
+        return DataAccessUtils.getSingleResult(result);
     }
 }

--- a/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -25,7 +25,7 @@ public class JdbcTemplate {
         return executeQuery(sql, PreparedStatement::executeUpdate, args);
     }
 
-    public <T> List<T> query(final String sql, RowMapper<T> rowMapper, Object... args) {
+    public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... args) {
         return executeQuery(sql, pstmt -> executeAndReturnResults(pstmt, rowMapper), args);
     }
 
@@ -36,7 +36,7 @@ public class JdbcTemplate {
         }
     }
 
-    private <T> T executeQuery(final String sql, final QueryExecutor<T> queryExecutor, Object... args) {
+    private <T> T executeQuery(final String sql, final QueryExecutor<T> queryExecutor, final Object... args) {
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
             StatementUtils.setArguments(pstmt, args);

--- a/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -26,12 +26,13 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> query(final String sql, RowMapper<T> rowMapper, Object... args) {
-        return executeQuery(sql, pstmt -> {
-            pstmt.executeQuery();
-            try (ResultSet rs = pstmt.executeQuery()) {
-                return DataAccessUtils.getResults(rowMapper, rs);
-            }
-        }, args);
+        return executeQuery(sql, pstmt -> query(pstmt, rowMapper), args);
+    }
+
+    private static <T> List<T> query(final PreparedStatement pstmt, final RowMapper<T> rowMapper) throws SQLException {
+        try (ResultSet rs = pstmt.executeQuery()) {
+            return DataAccessUtils.getResults(rowMapper, rs);
+        }
     }
 
     private <T> T executeQuery(final String sql, final QueryExecutor<T> queryExecutor, Object... args) {

--- a/jdbc/src/main/java/nextstep/jdbc/QueryExecutor.java
+++ b/jdbc/src/main/java/nextstep/jdbc/QueryExecutor.java
@@ -1,0 +1,10 @@
+package nextstep.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface QueryExecutor<T> {
+
+    T execute(PreparedStatement pstmt) throws SQLException;
+}

--- a/jdbc/src/main/java/nextstep/jdbc/support/DataAccessUtils.java
+++ b/jdbc/src/main/java/nextstep/jdbc/support/DataAccessUtils.java
@@ -14,7 +14,7 @@ public class DataAccessUtils {
     private DataAccessUtils() {
     }
 
-    public static <T> List<T> mapResultSetToList(final RowMapper<T> rowMapper, final ResultSet rs)
+    public static <T> List<T> getResults(final RowMapper<T> rowMapper, final ResultSet rs)
             throws SQLException {
         List<T> result = new ArrayList<>();
         while (rs.next()) {

--- a/jdbc/src/main/java/nextstep/jdbc/support/DataAccessUtils.java
+++ b/jdbc/src/main/java/nextstep/jdbc/support/DataAccessUtils.java
@@ -23,22 +23,11 @@ public class DataAccessUtils {
         return result;
     }
 
-    public static void validateResultSetSize(final ResultSet rs) throws SQLException {
-        int size = getResultSetSize(rs);
+    public static <T> T getSingleResult(final List<T> result) {
+        int size = result.size();
         if (size != 1) {
             throw new DataAccessException(String.format(INCORRECT_RESULT_SIZE_MESSAGE, size));
         }
-    }
-
-    private static int getResultSetSize(final ResultSet rs) throws SQLException {
-        rs.last();
-        int size = rs.getRow();
-        rs.beforeFirst();
-        return size;
-    }
-
-    public static <T> T mapResultSetToObject(final RowMapper<T> rowMapper, final ResultSet rs) throws SQLException {
-        rs.next();
-        return rowMapper.mapRow(rs, 1);
+        return result.get(0);
     }
 }

--- a/jdbc/src/test/java/nextstep/jdbc/BeanPropertyRowMapperTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/BeanPropertyRowMapperTest.java
@@ -39,7 +39,7 @@ class BeanPropertyRowMapperTest {
             this(null, null);
         }
 
-        public Data(Long id, String name) {
+        public Data(final Long id, final String name) {
             this.id = id;
             this.name = name;
         }

--- a/jdbc/src/test/java/nextstep/jdbc/BeanPropertyRowMapperTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/BeanPropertyRowMapperTest.java
@@ -1,0 +1,55 @@
+package nextstep.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.jupiter.api.Test;
+
+class BeanPropertyRowMapperTest {
+
+    @Test
+    void BeanPropertyRowMapper의_매핑_테스트() throws SQLException {
+        BeanPropertyRowMapper<Data> rowMapper = new BeanPropertyRowMapper<>(Data.class);
+        ResultSet rs = mock(ResultSet.class);
+
+        when(rs.getObject("id", Long.class)).thenReturn(1L);
+        when(rs.getObject("name", String.class)).thenReturn("name");
+
+        Data data = rowMapper.mapRow(rs, 0);
+
+        assertAll(
+                () -> assertThat(data.getId()).isEqualTo(1L),
+                () -> assertThat(data.getName()).isEqualTo("name"),
+                () -> verify(rs).getObject("id", Long.class),
+                () -> verify(rs).getObject("name", String.class)
+        );
+    }
+
+    static class Data {
+
+        private final Long id;
+        private final String name;
+
+        public Data() {
+            this(null, null);
+        }
+
+        public Data(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -57,7 +57,9 @@ class JdbcTemplateTest {
         assertAll(
                 () -> verify(dataSource).getConnection(),
                 () -> verify(conn).prepareStatement(sql),
-                () -> verify(pstmt, times(2)).setObject(anyInt(), any())
+                () -> verify(pstmt, times(2)).setObject(anyInt(), any()),
+                () -> verify(conn).close(),
+                () -> verify(pstmt).close()
         );
     }
 
@@ -77,7 +79,10 @@ class JdbcTemplateTest {
                 () -> verify(dataSource).getConnection(),
                 () -> verify(conn).prepareStatement(sql),
                 () -> verify(pstmt, times(0)).setObject(anyInt(), any()),
-                () -> verify(rs).next()
+                () -> verify(rs).next(),
+                () -> verify(conn).close(),
+                () -> verify(pstmt).close(),
+                () -> verify(rs).close()
         );
     }
 
@@ -100,7 +105,10 @@ class JdbcTemplateTest {
                 () -> verify(conn).prepareStatement(sql),
                 () -> verify(pstmt, times(0)).setObject(anyInt(), any()),
                 () -> verify(rs, times(2)).next(),
-                () -> verify(rs).getRow()
+                () -> verify(rs).getRow(),
+                () -> verify(conn).close(),
+                () -> verify(pstmt).close(),
+                () -> verify(rs).close()
         );
     }
 
@@ -121,7 +129,10 @@ class JdbcTemplateTest {
                 () -> verify(dataSource).getConnection(),
                 () -> verify(conn).prepareStatement(sql),
                 () -> verify(pstmt, times(0)).setObject(anyInt(), any()),
-                () -> verify(rs).next()
+                () -> verify(rs).next(),
+                () -> verify(conn).close(),
+                () -> verify(pstmt).close(),
+                () -> verify(rs).close()
         );
     }
 
@@ -145,7 +156,10 @@ class JdbcTemplateTest {
                 () -> verify(dataSource).getConnection(),
                 () -> verify(conn).prepareStatement(sql),
                 () -> verify(pstmt, times(0)).setObject(anyInt(), any()),
-                () -> verify(rs, times(3)).next()
+                () -> verify(rs, times(3)).next(),
+                () -> verify(conn).close(),
+                () -> verify(pstmt).close(),
+                () -> verify(rs).close()
         );
     }
 }

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -1,13 +1,10 @@
 package nextstep.jdbc;
 
-import static java.sql.ResultSet.CONCUR_READ_ONLY;
-import static java.sql.ResultSet.TYPE_SCROLL_INSENSITIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,8 +17,6 @@ import java.sql.SQLException;
 import java.util.List;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class JdbcTemplateTest {
 
@@ -37,7 +32,6 @@ class JdbcTemplateTest {
 
         when(dataSource.getConnection()).thenReturn(conn);
         when(conn.prepareStatement(sql)).thenReturn(pstmt);
-        when(conn.prepareStatement(sql, TYPE_SCROLL_INSENSITIVE, CONCUR_READ_ONLY)).thenReturn(pstmt);
         when(pstmt.executeUpdate()).thenThrow(SQLException.class);
         when(pstmt.executeQuery()).thenThrow(SQLException.class);
 
@@ -92,48 +86,66 @@ class JdbcTemplateTest {
         String sql = "";
 
         when(dataSource.getConnection()).thenReturn(conn);
-        when(conn.prepareStatement(sql, TYPE_SCROLL_INSENSITIVE, CONCUR_READ_ONLY)).thenReturn(pstmt);
+        when(conn.prepareStatement(sql)).thenReturn(pstmt);
         when(pstmt.executeQuery()).thenReturn(rs);
-        when(rs.last()).thenReturn(true);
-        when(rs.getRow()).thenReturn(1);
-        doNothing().when(rs)
-                .beforeFirst();
-        when(rs.next()).thenReturn(true);
+        when(rs.next()).thenReturn(true)
+                .thenReturn(false);
+        when(rs.getRow()).thenReturn(0);
 
         Object result = jdbcTemplate.queryForObject(sql, ((rs1, rowNum) -> "dummy"));
 
         assertAll(
                 () -> assertThat(result).isNotNull(),
                 () -> verify(dataSource).getConnection(),
-                () -> verify(conn).prepareStatement(sql, TYPE_SCROLL_INSENSITIVE, CONCUR_READ_ONLY),
+                () -> verify(conn).prepareStatement(sql),
                 () -> verify(pstmt, times(0)).setObject(anyInt(), any()),
-                () -> verify(rs).next(),
+                () -> verify(rs, times(2)).next(),
                 () -> verify(rs).getRow()
         );
     }
 
-    @ParameterizedTest
-    @ValueSource(ints = {0, 2})
-    void queryForObject의_조회_결과가_1개가_아니면_예외를_반환한다(final int resultSetSize) throws SQLException {
+    @Test
+    void queryForObject의_조회_결과가_0개면_예외를_반환한다() throws SQLException {
         String sql = "";
 
         when(dataSource.getConnection()).thenReturn(conn);
-        when(conn.prepareStatement(sql, TYPE_SCROLL_INSENSITIVE, CONCUR_READ_ONLY)).thenReturn(pstmt);
+        when(conn.prepareStatement(sql)).thenReturn(pstmt);
         when(pstmt.executeQuery()).thenReturn(rs);
-        when(rs.last()).thenReturn(true);
-        when(rs.getRow()).thenReturn(resultSetSize);
-        doNothing().when(rs)
-                .beforeFirst();
-        when(rs.next()).thenReturn(resultSetSize > 0);
+        when(rs.next()).thenReturn(false);
 
         assertAll(
                 () -> assertThatThrownBy(
                         () -> jdbcTemplate.queryForObject(sql, (rs1, rowNum) -> "dummy"))
-                        .isInstanceOf(DataAccessException.class),
+                        .isInstanceOf(DataAccessException.class)
+                        .hasMessage("Incorrect result size: expected 1, actual 0"),
                 () -> verify(dataSource).getConnection(),
-                () -> verify(conn).prepareStatement(sql, TYPE_SCROLL_INSENSITIVE, CONCUR_READ_ONLY),
+                () -> verify(conn).prepareStatement(sql),
                 () -> verify(pstmt, times(0)).setObject(anyInt(), any()),
-                () -> verify(rs).getRow()
+                () -> verify(rs).next()
+        );
+    }
+
+    @Test
+    void queryForObject의_조회_결과가_2개_이상이면_예외를_반환한다() throws SQLException {
+        String sql = "";
+
+        when(dataSource.getConnection()).thenReturn(conn);
+        when(conn.prepareStatement(sql)).thenReturn(pstmt);
+        when(pstmt.executeQuery()).thenReturn(rs);
+        when(rs.next()).thenReturn(true)
+                .thenReturn(true)
+                .thenReturn(false);
+        when(rs.getRow()).thenReturn(0);
+
+        assertAll(
+                () -> assertThatThrownBy(
+                        () -> jdbcTemplate.queryForObject(sql, (rs1, rowNum) -> "dummy"))
+                        .isInstanceOf(DataAccessException.class)
+                        .hasMessage("Incorrect result size: expected 1, actual 2"),
+                () -> verify(dataSource).getConnection(),
+                () -> verify(conn).prepareStatement(sql),
+                () -> verify(pstmt, times(0)).setObject(anyInt(), any()),
+                () -> verify(rs, times(3)).next()
         );
     }
 }


### PR DESCRIPTION
안녕하세요 열음 :) 2단계 미션으로 돌아왔습니다.

제 나름대로의 생각으로는 2단계 힌트중에 1단계 미션에서 이미 구현된 부분이 꽤 많다고 느꼈습니다. 반영되지 않은 부분이라면 템플릿 메서드 패턴 적용 정도였는데요, try ~ catchd에서 커넥션을 만들고 PreparedStatement를 만들고, 쿼리를 실행하는 부분들이 공통 로직이기 때문에 이 부분을 콜백 메서드를 만들어서 중복 제거가 되도록 만들었습니다.

그리고 기존에는 query와 queryForObject가 굉장이 애매하게 중복된 부분이 있었는데요, 이는 queryForObject도 바로 ResultSet을 가져와서 사용하기 때문이었는데, query의 결과로 나온 리스트를 가지고 데이터 개수를 판단하도록 로직을 변경했습니다. 굳이 객체로 만들 필요 없는 객체까지 만들 필요가 있냐는 의견도 있을 수 있지만, 개인적인 의견으로는 어차피 데이터베이스에서 row를 읽어오는 시간이 더 걸리지, 이미 읽어온 ResultSet을 객체로 매핑하는 부분은 크게 시간이 걸리지 않는다고 판단, query의 결과를 사용하더라도 성능상 큰 차이가 없을거라는 판단을 했습니다.

지난 1단계에서 코멘트 주셨던 cleanup의 경우, 테이블 네임을 가져와서 각각의 테이블에 대해 클린업을 해주는 부분의 문법이 각 벤더사마다 다 달라서 모든 DBMS에 대해 작동하는 cleanup을 만드는데 어려움이 있어 기존의 truncate.sql을 사용하는 방법을 유지했습니다.

마지막으로 2단계 뭐 더 할게 없을까 하다가... ORM처럼 자동으로 매핑해주는 BeanPropertyRowMapper도 한 번 만들어 봤습니다...

이번에도 좋은 리뷰 부탁드립니다 :)