### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 유콩(김유빈) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -2,61 +2,20 @@ package com.techcourse.dao;
 
 import com.techcourse.domain.UserHistory;
 import nextstep.jdbc.JdbcTemplate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 
 public class UserHistoryDao {
 
-    private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
-
-    private final DataSource dataSource;
-
-    public UserHistoryDao(final DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
+    private final JdbcTemplate jdbcTemplate;
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
-        this.dataSource = null;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
-
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
-
-            log.debug("query : {}", sql);
-
-            pstmt.setLong(1, userHistory.getUserId());
-            pstmt.setString(2, userHistory.getAccount());
-            pstmt.setString(3, userHistory.getPassword());
-            pstmt.setString(4, userHistory.getEmail());
-            pstmt.setObject(5, userHistory.getCreatedAt());
-            pstmt.setString(6, userHistory.getCreateBy());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+        jdbcTemplate.update(sql,
+            userHistory.getUserId(), userHistory.getAccount(), userHistory.getPassword(),
+            userHistory.getEmail(), userHistory.getCreatedAt(), userHistory.getCreateBy()
+        );
     }
 }

--- a/app/src/main/resources/clear.sql
+++ b/app/src/main/resources/clear.sql
@@ -1,1 +1,2 @@
 truncate table users;
+truncate table user_history;

--- a/app/src/test/java/com/techcourse/dao/UserHistoryDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserHistoryDaoTest.java
@@ -1,0 +1,67 @@
+package com.techcourse.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.techcourse.config.DataSourceConfig;
+import com.techcourse.domain.UserHistory;
+import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+
+import nextstep.jdbc.JdbcTemplate;
+
+class UserHistoryDaoTest {
+
+    private UserHistoryDao userHistoryDao;
+    private JdbcTemplate jdbcTemplate;
+    private DataSource dataSource;
+
+    @BeforeEach
+    void setUp() {
+        dataSource = DataSourceConfig.getInstance();
+        DatabasePopulatorUtils.init(dataSource);
+
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        userHistoryDao = new UserHistoryDao(jdbcTemplate);
+    }
+
+    @AfterEach
+    void tearDown() {
+        DatabasePopulatorUtils.clear(dataSource);
+    }
+
+    @DisplayName("사용자 로그를 남긴다")
+    @Test
+    void log() {
+        final UserHistory userHistory = new UserHistory(
+            1L, 1L, "account", "password", "email", "gugu"
+        );
+        userHistoryDao.log(userHistory);
+
+        final List<Object> userHistories = jdbcTemplate.query("select * from user_history",
+            resultSet -> new UserHistory(
+                resultSet.getLong("id"),
+                resultSet.getLong("user_id"),
+                resultSet.getString("account"),
+                resultSet.getString("password"),
+                resultSet.getString("email"),
+                resultSet.getString("created_by")
+            ));
+
+        assertAll(
+            () -> assertThat(userHistories).hasSize(1),
+            () -> assertThat(userHistories.get(0))
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt")
+                .isEqualTo(userHistory)
+        );
+    }
+}

--- a/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
+++ b/jdbc/src/main/java/nextstep/jdbc/JdbcTemplate.java
@@ -31,7 +31,7 @@ public class JdbcTemplate {
 
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
         final List<T> result = query(sql, rowMapper, args);
-        return extractOne(sql, result);
+        return extractOne(result);
     }
 
     public int update(final String sql, final Object... args) {
@@ -78,12 +78,12 @@ public class JdbcTemplate {
         return results;
     }
 
-    private <T> T extractOne(final String sql, final List<T> result) {
+    private <T> T extractOne(final List<T> result) {
         if (result.isEmpty()) {
-            throw new DataAccessException(String.format("조회 결과가 없습니다. [%s]", sql));
+            throw new DataAccessException("조회 결과가 없습니다.");
         }
         if (result.size() > 1) {
-            throw new DataAccessException(String.format("조회 결과가 1개 이상입니다. [%s]", sql));
+            throw new DataAccessException("조회 결과가 1개 이상입니다.");
         }
         return result.get(0);
     }

--- a/jdbc/src/main/java/nextstep/jdbc/QueryExecutor.java
+++ b/jdbc/src/main/java/nextstep/jdbc/QueryExecutor.java
@@ -1,0 +1,10 @@
+package nextstep.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface QueryExecutor<T> {
+
+    T run(PreparedStatement pstmt) throws SQLException;
+}


### PR DESCRIPTION
안녕하세요 아스피!
2단계 미션 제출합니다ㅎㅎ

지난번 피드백이 고민해볼 문제들이어서 좋았어요
이번에도 좋은 피드백 기대하겠습니다! 😄

## ❗️ 1단계 피드백
지난번 피드백 중 [예외 메시지에 쿼리문 전달](https://github.com/woowacourse/jwp-dashboard-jdbc/pull/114#discussion_r987522797) 이 있었는데요, 결론은 쿼리문을 삭제했습니다ㅠ.ㅠ

저는 사용자가 요청한 (데이터가 담긴) 쿼리문을 보여주어 빠르게 문제를 인식하도록 했었는데 제가 추가한 쿼리문은 파라미터가 셋팅되지 않은 쿼리문이더라구요. 아스피가 말해주어서 그때 알았습니다 😢 원래의 목적대로 파라미터가 셋팅된 쿼리문을 전달하기에는 편의성을 위해 추가하는 과정 때문에 코드 내부 로직이 복잡해지고, 로그로도 남기기 때문에 불필요하다고 느꼈습니다. 

## ✓ 2단계 변경사항
- JdbcTemplate 템플릿 메서드 패턴 적용
- UserHistoryDao 에서 JdbcTemplate 사용
- UserService 테스트 추가
