### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 여우(조승현) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 2단계에서는 뭘 해야 하지?
 * [x] SQL문의 매개변수와 값 설정 - ? 말고 namedParameter를 쓸 수 있게 해볼까?
-* [ ] 예외 처리 - UncheckedException으로 바꾸어줄까?
+* [x] 예외 처리 - UncheckedException으로 바꾸어줄까?
 
 
 * [ ] 연결 매개변수 설정 - 무슨뜻,,??

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JDBC 라이브러리 구현하기
 
 2단계에서는 뭘 해야 하지?
-* [ ] SQL문의 매개변수와 값 설정 - ? 말고 namedParameter를 쓸 수 있게 해볼까?
+* [x] SQL문의 매개변수와 값 설정 - ? 말고 namedParameter를 쓸 수 있게 해볼까?
 * [ ] 예외 처리 - UncheckedException으로 바꾸어줄까?
 
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # JDBC 라이브러리 구현하기
+
+2단계에서는 뭘 해야 하지?
+* [ ] SQL문의 매개변수와 값 설정 - ? 말고 namedParameter를 쓸 수 있게 해볼까?
+* [ ] 예외 처리 - UncheckedException으로 바꾸어줄까?
+
+
+* [ ] 연결 매개변수 설정 - 무슨뜻,,??
+* [x] Connection 생성
+* [x] ResultSet 생성
+* [x] Statement 준비 및 실행
+* [x] Connection, Statement, ResultSet 객체 close

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -4,6 +4,7 @@ import com.techcourse.domain.User;
 import java.util.List;
 import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 
 public class UserDao {
 
@@ -19,35 +20,30 @@ public class UserDao {
     }
 
     public void update(final User user) {
-        jdbcTemplate.update("update users set account = ?, password = ?, email = ? where id = ?",
-                user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
+        final String sql = "update users set (account, password, email) = (?, ?, ?) where id = ?";
+        jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
     }
 
     public List<User> findAll() {
-        return jdbcTemplate.query("select * from users", (rs, rowNum) -> new User(
-                rs.getLong(1),
-                rs.getString(2),
-                rs.getString(3),
-                rs.getString(4)));
+        final String sql = "select * from users";
+        return jdbcTemplate.query(sql, getUserRowMapper());
     }
 
     public User findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
-
-        return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> new User(
-                rs.getLong(1),
-                rs.getString(2),
-                rs.getString(3),
-                rs.getString(4)), id);
+        return jdbcTemplate.queryForObject(sql, getUserRowMapper(), id);
     }
 
     public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
+        return jdbcTemplate.queryForObject(sql, getUserRowMapper(), account);
+    }
 
-        return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> new User(
-                rs.getLong(1),
-                rs.getString(2),
-                rs.getString(3),
-                rs.getString(4)), account);
+    private static RowMapper<User> getUserRowMapper() {
+        return (rs, rowNum) -> new User(
+                rs.getLong("id"),
+                rs.getString("account"),
+                rs.getString("password"),
+                rs.getString("email"));
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserDaoWithJdbcTemplate.java
+++ b/app/src/main/java/com/techcourse/dao/UserDaoWithJdbcTemplate.java
@@ -1,16 +1,17 @@
 package com.techcourse.dao;
 
 import com.techcourse.domain.User;
+import com.techcourse.repository.UserRepository;
 import java.util.List;
 import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
-public class UserDao {
+public class UserDaoWithJdbcTemplate implements UserRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public UserDao(final DataSource dataSource) {
+    public UserDaoWithJdbcTemplate(final DataSource dataSource) {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 

--- a/app/src/main/java/com/techcourse/dao/UserDaoWithNamedParameterJdbcTemplate.java
+++ b/app/src/main/java/com/techcourse/dao/UserDaoWithNamedParameterJdbcTemplate.java
@@ -1,0 +1,63 @@
+package com.techcourse.dao;
+
+import com.techcourse.domain.User;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+public class UserDaoWithNamedParameterJdbcTemplate {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public UserDaoWithNamedParameterJdbcTemplate(final DataSource dataSource) {
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    public void insert(final User user) {
+        final var sql = "insert into users (account, password, email) values (:account, :password, :email)";
+        final HashMap<String, Object> parameters = new HashMap<>();
+        parameters.put("account", user.getAccount());
+        parameters.put("password", user.getPassword());
+        parameters.put("email", user.getEmail());
+        jdbcTemplate.update(sql, parameters);
+    }
+
+    public void update(final User user) {
+        final String sql = "update users set (account, password, email) = (:account, :password, :email) where id = :id";
+        final HashMap<String, Object> parameters = new HashMap<>();
+        parameters.put("account", user.getAccount());
+        parameters.put("password", user.getPassword());
+        parameters.put("email", user.getEmail());
+        parameters.put("id", user.getId());
+        jdbcTemplate.update(sql, parameters);
+    }
+
+    public List<User> findAll() {
+        final String sql = "select * from users";
+        return jdbcTemplate.query(sql, getUserRowMapper(), Map.of());
+    }
+
+    public User findById(final Long id) {
+        final var sql = "select id, account, password, email from users where id = :id";
+        final HashMap<String, Object> parameters = new HashMap<>();
+        parameters.put("id", id);
+        return jdbcTemplate.queryForObject(sql, getUserRowMapper(), parameters);
+    }
+
+    public User findByAccount(final String account) {
+        final var sql = "select id, account, password, email from users where account = :account";
+        final HashMap<String, Object> parameters = new HashMap<>();
+        parameters.put("account", account);
+        return jdbcTemplate.queryForObject(sql, getUserRowMapper(), parameters);
+    }
+
+    private static RowMapper<User> getUserRowMapper() {
+        return (rs, rowNum) -> new User(
+                rs.getLong("id"),
+                rs.getString("account"),
+                rs.getString("password"),
+                rs.getString("email"));
+    }
+}

--- a/app/src/main/java/com/techcourse/repository/UserRepository.java
+++ b/app/src/main/java/com/techcourse/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package com.techcourse.repository;
+
+import com.techcourse.domain.User;
+import java.util.List;
+
+public interface UserRepository {
+
+    void insert(final User user);
+
+    void update(final User user);
+
+    List<User> findAll();
+
+    User findById(final Long id);
+
+    User findByAccount(final String account);
+}

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,16 +1,16 @@
 package com.techcourse.service;
 
-import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserDaoWithJdbcTemplate;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
 
 public class UserService {
 
-    private final UserDao userDao;
+    private final UserDaoWithJdbcTemplate userDao;
     private final UserHistoryDao userHistoryDao;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+    public UserService(final UserDaoWithJdbcTemplate userDao, final UserHistoryDao userHistoryDao) {
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
     }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UserDaoTest {
 
@@ -41,6 +42,14 @@ class UserDaoTest {
         final var user = userDao.findByAccount(account);
 
         assertThat(user.getAccount()).isEqualTo(account);
+    }
+
+    @Test
+    void findByAccountIncorrectColumnSize() {
+        userDao.insert(new User("gugu", "password", "hkkang@woowahan.com"));
+
+        assertThatThrownBy(() -> userDao.findByAccount("gugu"))
+                .hasMessageContaining("결과가 1개인 줄 알았는데, 2개 나왔서!");
     }
 
     @Test

--- a/app/src/test/java/com/techcourse/dao/UserDaoWithJdbcTemplateTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoWithJdbcTemplateTest.java
@@ -3,8 +3,12 @@ package com.techcourse.dao;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.NamedParameterJdbcTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,12 +16,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class UserDaoWithJdbcTemplateTest {
 
     private UserDaoWithJdbcTemplate userDao;
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     @BeforeEach
     void setup() {
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+        final DataSource dataSource = DataSourceConfig.getInstance();
+        DatabasePopulatorUtils.execute(dataSource);
 
-        userDao = new UserDaoWithJdbcTemplate(DataSourceConfig.getInstance());
+        userDao = new UserDaoWithJdbcTemplate(dataSource);
+        namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }
@@ -31,7 +38,8 @@ class UserDaoWithJdbcTemplateTest {
 
     @Test
     void findById() {
-        final var user = userDao.findById(1L);
+        final long savedUserId = userDao.findAll().get(0).getId();
+        final var user = userDao.findById(savedUserId);
 
         assertThat(user.getAccount()).isEqualTo("gugu");
     }
@@ -39,6 +47,7 @@ class UserDaoWithJdbcTemplateTest {
     @Test
     void findByAccount() {
         final var account = "gugu";
+
         final var user = userDao.findByAccount(account);
 
         assertThat(user.getAccount()).isEqualTo(account);
@@ -66,13 +75,20 @@ class UserDaoWithJdbcTemplateTest {
     @Test
     void update() {
         final var newPassword = "password99";
-        final var user = userDao.findById(1L);
+        final long savedUserId = userDao.findAll().get(0).getId();
+
+        final var user = userDao.findById(savedUserId);
         user.changePassword(newPassword);
 
         userDao.update(user);
 
-        final var actual = userDao.findById(1L);
+        final var actual = userDao.findById(savedUserId);
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
+    }
+
+    @AfterEach
+    void reset() {
+        namedParameterJdbcTemplate.update("truncate table users", Map.of());
     }
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoWithJdbcTemplateTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoWithJdbcTemplateTest.java
@@ -1,0 +1,78 @@
+package com.techcourse.dao;
+
+import com.techcourse.config.DataSourceConfig;
+import com.techcourse.domain.User;
+import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserDaoWithJdbcTemplateTest {
+
+    private UserDaoWithJdbcTemplate userDao;
+
+    @BeforeEach
+    void setup() {
+        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+
+        userDao = new UserDaoWithJdbcTemplate(DataSourceConfig.getInstance());
+        final var user = new User("gugu", "password", "hkkang@woowahan.com");
+        userDao.insert(user);
+    }
+
+    @Test
+    void findAll() {
+        final var users = userDao.findAll();
+
+        assertThat(users).isNotEmpty();
+    }
+
+    @Test
+    void findById() {
+        final var user = userDao.findById(1L);
+
+        assertThat(user.getAccount()).isEqualTo("gugu");
+    }
+
+    @Test
+    void findByAccount() {
+        final var account = "gugu";
+        final var user = userDao.findByAccount(account);
+
+        assertThat(user.getAccount()).isEqualTo(account);
+    }
+
+    @Test
+    void findByAccountIncorrectColumnSize() {
+        userDao.insert(new User("gugu", "password", "hkkang@woowahan.com"));
+
+        assertThatThrownBy(() -> userDao.findByAccount("gugu"))
+                .hasMessageContaining("결과가 1개인 줄 알았는데, 2개 나왔서!");
+    }
+
+    @Test
+    void insert() {
+        final var account = "insert-gugu";
+        final var user = new User(account, "password", "hkkang@woowahan.com");
+        userDao.insert(user);
+
+        final var actual = userDao.findById(2L);
+
+        assertThat(actual.getAccount()).isEqualTo(account);
+    }
+
+    @Test
+    void update() {
+        final var newPassword = "password99";
+        final var user = userDao.findById(1L);
+        user.changePassword(newPassword);
+
+        userDao.update(user);
+
+        final var actual = userDao.findById(1L);
+
+        assertThat(actual.getPassword()).isEqualTo(newPassword);
+    }
+}

--- a/app/src/test/java/com/techcourse/dao/UserDaoWithNamedParameterJdbcTemplateTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoWithNamedParameterJdbcTemplateTest.java
@@ -1,23 +1,23 @@
 package com.techcourse.dao;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+class UserDaoWithNamedParameterJdbcTemplateTest {
 
-class UserDaoTest {
-
-    private UserDao userDao;
+    private UserDaoWithNamedParameterJdbcTemplate userDao;
 
     @BeforeEach
     void setup() {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
 
-        userDao = new UserDao(DataSourceConfig.getInstance());
+        userDao = new UserDaoWithNamedParameterJdbcTemplate(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.techcourse.config.DataSourceConfig;
-import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserDaoWithJdbcTemplate;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
@@ -18,12 +18,12 @@ import org.springframework.dao.DataAccessException;
 class UserServiceTest {
 
     private DataSource dataSource;
-    private UserDao userDao;
+    private UserDaoWithJdbcTemplate userDao;
 
     @BeforeEach
     void setUp() {
         this.dataSource = DataSourceConfig.getInstance();
-        this.userDao = new UserDao(DataSourceConfig.getInstance());
+        this.userDao = new UserDaoWithJdbcTemplate(DataSourceConfig.getInstance());
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");

--- a/jdbc/src/main/java/org/springframework/dao/BatchUpdateException.java
+++ b/jdbc/src/main/java/org/springframework/dao/BatchUpdateException.java
@@ -1,0 +1,31 @@
+package org.springframework.dao;
+
+/**
+ * 예외 원본 번역 :
+ * 배치 업데이트 작업 도중 잘생한 에러를 나타내는 예외입니다.
+ * BatchUpdateException은 updateCount라는 값을 받는 특징이 있는데,
+ * updateCount는 에러 발생 전까지 성공적으로 수행 완료한 배치 작업의 수를 나타냅니다.
+ * updateCount의 배열 순서는 배치 작업에 배치된(..) 작업의 순서를 그대로 따라갑니다.
+ */
+public class BatchUpdateException extends DataAccessException {
+    public BatchUpdateException() {
+        super();
+    }
+
+    public BatchUpdateException(final String message, final Throwable cause, final boolean enableSuppression,
+                                final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public BatchUpdateException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public BatchUpdateException(final String message) {
+        super(message);
+    }
+
+    public BatchUpdateException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/DataTruncation.java
+++ b/jdbc/src/main/java/org/springframework/dao/DataTruncation.java
@@ -1,0 +1,28 @@
+package org.springframework.dao;
+
+/**
+ * 예외 원본 번역 :
+ * MaxFieldSize를 초과하는 등의 이유로 삽입할 데이터가 예치지 않게 잘려나갔을 때 발생하는 예외입니다.
+ */
+public class DataTruncation extends DataAccessException {
+    public DataTruncation() {
+        super();
+    }
+
+    public DataTruncation(final String message, final Throwable cause, final boolean enableSuppression,
+                          final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public DataTruncation(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public DataTruncation(final String message) {
+        super(message);
+    }
+
+    public DataTruncation(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/RowSetWarning.java
+++ b/jdbc/src/main/java/org/springframework/dao/RowSetWarning.java
@@ -1,0 +1,27 @@
+package org.springframework.dao;
+
+/**
+ * RowSet(데이터베이스 결과 집합(ResultSet)을 자바 객체로 표현하고 다루기 위한 인터페이스)와 관련된 예외입니다.
+ */
+public class RowSetWarning extends DataAccessException {
+    public RowSetWarning() {
+        super();
+    }
+
+    public RowSetWarning(final String message, final Throwable cause, final boolean enableSuppression,
+                         final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public RowSetWarning(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public RowSetWarning(final String message) {
+        super(message);
+    }
+
+    public RowSetWarning(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLClientInfoException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLClientInfoException.java
@@ -1,0 +1,29 @@
+package org.springframework.dao;
+
+/**
+ * 하나 또는 이상의 연결 정보를 가지고 데이터베이스 연결을 맺지 못했을 때 발생하는 예외입니다.
+ * SQLClientInfoException에는 failedProperties라는 필드가 있어서,
+ * 연결에 실패한 연결 정보를 조회할 수 있습니다.
+ */
+public class SQLClientInfoException extends DataAccessException {
+    public SQLClientInfoException() {
+        super();
+    }
+
+    public SQLClientInfoException(final String message, final Throwable cause, final boolean enableSuppression,
+                                  final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLClientInfoException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLClientInfoException(final String message) {
+        super(message);
+    }
+
+    public SQLClientInfoException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLDataException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLDataException.java
@@ -1,0 +1,28 @@
+package org.springframework.dao;
+
+/**
+ * SQLState(데이터베이스 관련 예외의 유형과 원인을 식별하는 표준화된 5자리 식별자) 값이 22이거나 그 아래일 때 발생하는 예외입니다. 데이터 변환 뿐 아니라, 0으로 나누거나 잘못된 함수 호출 등 다양한
+ * 원인에 의해 발생할 수 있습니다. 애플리케이션에서 사용하는 각 데이터베이스 벤더사 문서를 찾아 정확한 원인을 파악할 수 있습니다.
+ */
+public class SQLDataException extends DataAccessException {
+    public SQLDataException() {
+        super();
+    }
+
+    public SQLDataException(final String message, final Throwable cause, final boolean enableSuppression,
+                            final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLDataException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLDataException(final String message) {
+        super(message);
+    }
+
+    public SQLDataException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLExceptionTranslator.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLExceptionTranslator.java
@@ -54,7 +54,18 @@ public class SQLExceptionTranslator {
     }
 
     public static DataAccessException translate(SQLException sqlException) {
-        final Class<? extends DataAccessException> dataAccessException = exceptions.get(sqlException.getClass());
+        Class<? extends DataAccessException> dataAccessException = null;
+        for (Class<? extends SQLException> exception : exceptions.keySet()) {
+            if (exception.isAssignableFrom(sqlException.getClass())) {
+                dataAccessException = exceptions.get(exception);
+                break;
+            }
+        }
+
+        if (dataAccessException == null) {
+            throw new DataAccessException(sqlException);
+        }
+
         try {
             final Constructor<? extends DataAccessException> constructor = dataAccessException.getDeclaredConstructor(Throwable.class);
             return constructor.newInstance(sqlException);

--- a/jdbc/src/main/java/org/springframework/dao/SQLExceptionTranslator.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLExceptionTranslator.java
@@ -1,0 +1,65 @@
+package org.springframework.dao;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.sql.BatchUpdateException;
+import java.sql.DataTruncation;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLDataException;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.SQLInvalidAuthorizationSpecException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLNonTransientException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLSyntaxErrorException;
+import java.sql.SQLTimeoutException;
+import java.sql.SQLTransactionRollbackException;
+import java.sql.SQLTransientConnectionException;
+import java.sql.SQLTransientException;
+import java.sql.SQLWarning;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.rowset.RowSetWarning;
+import javax.sql.rowset.serial.SerialException;
+import javax.sql.rowset.spi.SyncFactoryException;
+import javax.sql.rowset.spi.SyncProviderException;
+
+public class SQLExceptionTranslator {
+
+    public static final Map<Class<? extends SQLException>, Class<? extends DataAccessException>> exceptions = new HashMap<>();
+
+    static {
+        exceptions.put(BatchUpdateException.class, org.springframework.dao.BatchUpdateException.class);
+        exceptions.put(DataTruncation.class, org.springframework.dao.DataTruncation.class);
+        exceptions.put(RowSetWarning.class, org.springframework.dao.RowSetWarning.class);
+        exceptions.put(SerialException.class, org.springframework.dao.SerialException.class);
+        exceptions.put(SQLClientInfoException.class, org.springframework.dao.SQLClientInfoException.class);
+        exceptions.put(SQLDataException.class, org.springframework.dao.SQLDataException.class);
+        exceptions.put(SQLFeatureNotSupportedException.class, org.springframework.dao.SQLFeatureNotSupportedException.class);
+        exceptions.put(SQLIntegrityConstraintViolationException.class, org.springframework.dao.SQLIntegrityConstraintViolationException.class);
+        exceptions.put(SQLInvalidAuthorizationSpecException.class, org.springframework.dao.SQLIntegrityConstraintViolationException.class);
+        exceptions.put(SQLNonTransientConnectionException.class, org.springframework.dao.SQLNonTransientConnectionException.class);
+        exceptions.put(SQLNonTransientException.class, org.springframework.dao.SQLNonTransientException.class);
+        exceptions.put(SQLRecoverableException.class, org.springframework.dao.SQLRecoverableException.class);
+        exceptions.put(SQLSyntaxErrorException.class, org.springframework.dao.SQLSyntaxErrorException.class);
+        exceptions.put(SQLTimeoutException.class, org.springframework.dao.SQLTimeoutException.class);
+        exceptions.put(SQLTransactionRollbackException.class, org.springframework.dao.SQLTransactionRollbackException.class);
+        exceptions.put(SQLTransientConnectionException.class, org.springframework.dao.SQLTransientConnectionException.class);
+        exceptions.put(SQLTransientException.class, org.springframework.dao.SQLTransientException.class);
+        exceptions.put(SQLWarning.class, org.springframework.dao.SQLWarning.class);
+        exceptions.put(SyncFactoryException.class, org.springframework.dao.SyncFactoryException.class);
+        exceptions.put(SyncProviderException.class, org.springframework.dao.SyncProviderException.class);
+    }
+
+    public static DataAccessException translate(SQLException sqlException) {
+        final Class<? extends DataAccessException> dataAccessException = exceptions.get(sqlException.getClass());
+        try {
+            final Constructor<? extends DataAccessException> constructor = dataAccessException.getDeclaredConstructor(Throwable.class);
+            return constructor.newInstance(sqlException);
+        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+            throw new DataAccessException(sqlException);
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLFeatureNotSupportedException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLFeatureNotSupportedException.java
@@ -1,0 +1,28 @@
+package org.springframework.dao;
+
+/**
+ * SQLState 값이 '0A'일 때 발생하는 예외입니다.
+ * JDBC 드라이버가 특정 JDBC 기능을 지원하지 않을 때 발생합니다.
+ */
+public class SQLFeatureNotSupportedException extends DataAccessException {
+    public SQLFeatureNotSupportedException() {
+        super();
+    }
+
+    public SQLFeatureNotSupportedException(final String message, final Throwable cause, final boolean enableSuppression,
+                                           final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLFeatureNotSupportedException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLFeatureNotSupportedException(final String message) {
+        super(message);
+    }
+
+    public SQLFeatureNotSupportedException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLIntegrityConstraintViolationException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLIntegrityConstraintViolationException.java
@@ -1,0 +1,29 @@
+package org.springframework.dao;
+
+/**
+ * SQLState가 23이거나 데이터베이스 벤더의 특정 값일 때 발생하는 예외입니다.
+ * 기본키 또는 외래키의 무결성 제약을 위배했을 때 발생하는 예외입니다.
+ */
+public class SQLIntegrityConstraintViolationException extends DataAccessException {
+    public SQLIntegrityConstraintViolationException() {
+        super();
+    }
+
+    public SQLIntegrityConstraintViolationException(final String message, final Throwable cause,
+                                                    final boolean enableSuppression,
+                                                    final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLIntegrityConstraintViolationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLIntegrityConstraintViolationException(final String message) {
+        super(message);
+    }
+
+    public SQLIntegrityConstraintViolationException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLInvalidAuthorizationSpecException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLInvalidAuthorizationSpecException.java
@@ -1,0 +1,29 @@
+package org.springframework.dao;
+
+/**
+ * SQLState 값이 28이거나, 데이터베이스의 고유 값에 따라 발생하는 예외입니다.
+ * 연결 설정 중 사용된 인가 정보가 유효하지 않을 때 발생하는 예외입니다.
+ */
+public class SQLInvalidAuthorizationSpecException extends DataAccessException {
+    public SQLInvalidAuthorizationSpecException() {
+        super();
+    }
+
+    public SQLInvalidAuthorizationSpecException(final String message, final Throwable cause,
+                                                final boolean enableSuppression,
+                                                final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLInvalidAuthorizationSpecException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLInvalidAuthorizationSpecException(final String message) {
+        super(message);
+    }
+
+    public SQLInvalidAuthorizationSpecException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLNonTransientConnectionException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLNonTransientConnectionException.java
@@ -1,0 +1,28 @@
+package org.springframework.dao;
+
+/**
+ * SQLNonTransientException 중 커넥션 연결과 관련된 예외입니다.
+ */
+public class SQLNonTransientConnectionException extends DataAccessException {
+    public SQLNonTransientConnectionException() {
+        super();
+    }
+
+    public SQLNonTransientConnectionException(final String message, final Throwable cause,
+                                              final boolean enableSuppression,
+                                              final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLNonTransientConnectionException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLNonTransientConnectionException(final String message) {
+        super(message);
+    }
+
+    public SQLNonTransientConnectionException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLNonTransientException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLNonTransientException.java
@@ -1,0 +1,35 @@
+package org.springframework.dao;
+
+/**
+ * 예외 발생 원인을 제거하지 않는 이상 재시도해도 똑같이 발생하는 예외들의 상위 집합입니다.
+ * 해당 예외의 하위에 속하는 예외들로는
+ * SQLDataException
+ * SQLFeatureNotSupportedException
+ * SQLIntegrityConstraintViolationException
+ * SQLInvalidAuthorizationSpecException
+ * SQLNonTransientConnectionException
+ * SQLSyntaxErrorException
+ * 이 있습니다.
+ */
+public class SQLNonTransientException extends DataAccessException {
+    public SQLNonTransientException() {
+        super();
+    }
+
+    public SQLNonTransientException(final String message, final Throwable cause, final boolean enableSuppression,
+                                    final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLNonTransientException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLNonTransientException(final String message) {
+        super(message);
+    }
+
+    public SQLNonTransientException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLRecoverableException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLRecoverableException.java
@@ -1,0 +1,27 @@
+package org.springframework.dao;
+
+/**
+ * 작업이 실패했으나, 애플리케이션 영역에서 복구 작업을 한 후 전체 트랜잭션을 다시 수행한다면 성공할 가능성이 있는 경우 발생하는 예외입니다.
+ */
+public class SQLRecoverableException extends DataAccessException {
+    public SQLRecoverableException() {
+        super();
+    }
+
+    public SQLRecoverableException(final String message, final Throwable cause, final boolean enableSuppression,
+                                   final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLRecoverableException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLRecoverableException(final String message) {
+        super(message);
+    }
+
+    public SQLRecoverableException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLSyntaxErrorException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLSyntaxErrorException.java
@@ -1,0 +1,28 @@
+package org.springframework.dao;
+
+/**
+ * SQLState 값이 42이거나, 데이터베이스의 고유 값에 따라 발생하는 예외입니다.
+ * 실행중인 쿼리가 SQL 문법에 위배되는 경우 발생하는 예외입니다.
+ */
+public class SQLSyntaxErrorException extends DataAccessException {
+    public SQLSyntaxErrorException() {
+        super();
+    }
+
+    public SQLSyntaxErrorException(final String message, final Throwable cause, final boolean enableSuppression,
+                                   final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLSyntaxErrorException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLSyntaxErrorException(final String message) {
+        super(message);
+    }
+
+    public SQLSyntaxErrorException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLTimeoutException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLTimeoutException.java
@@ -1,0 +1,28 @@
+package org.springframework.dao;
+
+/**
+ * 타임아웃과 관련된 설정값(setQueryTimeout, DriverManager.setLoginTimeout, DataSource.setLoginTimeout,XADataSource.setLoginTimeout)
+ * 의 만료에 의해 발생하는 예외입니다.
+ */
+public class SQLTimeoutException extends DataAccessException {
+    public SQLTimeoutException() {
+        super();
+    }
+
+    public SQLTimeoutException(final String message, final Throwable cause, final boolean enableSuppression,
+                               final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLTimeoutException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLTimeoutException(final String message) {
+        super(message);
+    }
+
+    public SQLTimeoutException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLTransactionRollbackException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLTransactionRollbackException.java
@@ -1,0 +1,28 @@
+package org.springframework.dao;
+
+/**
+ * SQLState 값이 40이거나, 각 데이터베이스 벤더사의 고유 상황에 따라 발생하는 예외입니다.
+ * 데드락과 같은 트랜잭션 동기화 실패로 인해 트랜잭션이 자동으로 롤백되었을 때 발생하는 예외입니다.
+ */
+public class SQLTransactionRollbackException extends DataAccessException {
+    public SQLTransactionRollbackException() {
+        super();
+    }
+
+    public SQLTransactionRollbackException(final String message, final Throwable cause, final boolean enableSuppression,
+                                           final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLTransactionRollbackException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLTransactionRollbackException(final String message) {
+        super(message);
+    }
+
+    public SQLTransactionRollbackException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLTransientConnectionException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLTransientConnectionException.java
@@ -1,0 +1,28 @@
+package org.springframework.dao;
+
+/**
+ * SQLState 값이 08 또는 데이터베이스 벤더 고유의 값에 따라 발생하는 예외입니다.
+ * 데이터베이스 연결에 실패했을 경우 발생하는 예외입니다. 연결에 실패했을 때 애플리케이션 레벨에서 이 예외를 발생하지 않는 경우, 연결에 실패했는데도 성공한 것으로 간주될 수 있습니다.
+ */
+public class SQLTransientConnectionException extends DataAccessException {
+    public SQLTransientConnectionException() {
+        super();
+    }
+
+    public SQLTransientConnectionException(final String message, final Throwable cause, final boolean enableSuppression,
+                                           final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLTransientConnectionException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLTransientConnectionException(final String message) {
+        super(message);
+    }
+
+    public SQLTransientConnectionException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLTransientException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLTransientException.java
@@ -1,0 +1,32 @@
+package org.springframework.dao;
+
+/**
+ * 같은 조건으로 재시도시 성공할 가능성이 있는 예외들의 상위 집합입니다.
+ * SQLTransientException의 하위 예외로는
+ * SQLTimeoutException
+ * SQLTransactionRollbackException
+ * SQLTransientConnectionException
+ * 이 있습니다.
+ */
+public class SQLTransientException extends DataAccessException {
+    public SQLTransientException() {
+        super();
+    }
+
+    public SQLTransientException(final String message, final Throwable cause, final boolean enableSuppression,
+                                 final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLTransientException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLTransientException(final String message) {
+        super(message);
+    }
+
+    public SQLTransientException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SQLWarning.java
+++ b/jdbc/src/main/java/org/springframework/dao/SQLWarning.java
@@ -1,0 +1,27 @@
+package org.springframework.dao;
+
+/**
+ * 데이터베이스 연결 과정에서 발생하는 예외입니다.
+ * Connection, Statement, ResultSet으로부터 발생할 수 있습니다.
+ */
+public class SQLWarning extends DataAccessException {
+    public SQLWarning() {
+    }
+
+    public SQLWarning(final String message, final Throwable cause, final boolean enableSuppression,
+                      final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SQLWarning(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SQLWarning(final String message) {
+        super(message);
+    }
+
+    public SQLWarning(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SerialException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SerialException.java
@@ -1,0 +1,27 @@
+package org.springframework.dao;
+
+/**
+ * BLOB, CLOB, STRUCT같은 SQL 타입 또는 DATALINK나 JAVAOBJECT같은 배열 자료를 직렬화 또는 역직렬화하는 과정에서 발생하는 예외입니다.
+ */
+public class SerialException extends DataAccessException {
+    public SerialException() {
+        super();
+    }
+
+    public SerialException(final String message, final Throwable cause, final boolean enableSuppression,
+                           final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SerialException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SerialException(final String message) {
+        super(message);
+    }
+
+    public SerialException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SyncFactoryException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SyncFactoryException.java
@@ -1,0 +1,27 @@
+package org.springframework.dao;
+
+/**
+ * 데이터 동기화에 사용되는 SyncFactory와 관련된 예외입니다.
+ */
+public class SyncFactoryException extends DataAccessException {
+    public SyncFactoryException() {
+        super();
+    }
+
+    public SyncFactoryException(final String message, final Throwable cause, final boolean enableSuppression,
+                                final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SyncFactoryException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SyncFactoryException(final String message) {
+        super(message);
+    }
+
+    public SyncFactoryException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/dao/SyncProviderException.java
+++ b/jdbc/src/main/java/org/springframework/dao/SyncProviderException.java
@@ -1,0 +1,28 @@
+package org.springframework.dao;
+
+/**
+ * SyncProvider라는, Java에서 데이터 동시과흫 관리하는 인터페이스 사용 도중 발생하는 예외합니다.
+ * 주로 데이터 동기화 작업 중 발생하는 문제나 오류를 나타내며, 데이터베이스나 다른 데이터 저장소 간의 동기화 작업에서 발생할 수 있습니다.
+ */
+public class SyncProviderException extends DataAccessException {
+    public SyncProviderException() {
+        super();
+    }
+
+    public SyncProviderException(final String message, final Throwable cause, final boolean enableSuppression,
+                                 final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public SyncProviderException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SyncProviderException(final String message) {
+        super(message);
+    }
+
+    public SyncProviderException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
+import org.springframework.dao.SQLExceptionTranslator;
 
 public class JdbcTemplate {
 
@@ -31,7 +32,7 @@ public class JdbcTemplate {
             return pstmt.executeUpdate();
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw SQLExceptionTranslator.translate(e);
         }
     }
 
@@ -59,7 +60,7 @@ public class JdbcTemplate {
             }
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw SQLExceptionTranslator.translate(e);
         }
     }
 
@@ -91,7 +92,7 @@ public class JdbcTemplate {
             }
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw SQLExceptionTranslator.translate(e);
         }
     }
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/NamedParameterJdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/NamedParameterJdbcTemplate.java
@@ -13,6 +13,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.SQLExceptionTranslator;
 
 public class NamedParameterJdbcTemplate {
 
@@ -34,7 +35,7 @@ public class NamedParameterJdbcTemplate {
             return pstmt.executeUpdate();
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw SQLExceptionTranslator.translate(e);
         }
     }
 
@@ -62,7 +63,7 @@ public class NamedParameterJdbcTemplate {
             }
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw SQLExceptionTranslator.translate(e);
         }
     }
 
@@ -94,7 +95,7 @@ public class NamedParameterJdbcTemplate {
             }
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw SQLExceptionTranslator.translate(e);
         }
     }
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/NamedParameterJdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/NamedParameterJdbcTemplate.java
@@ -1,0 +1,132 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+
+public class NamedParameterJdbcTemplate {
+
+    private static final Logger log = LoggerFactory.getLogger(NamedParameterJdbcTemplate.class);
+
+    private final DataSource dataSource;
+
+    public NamedParameterJdbcTemplate(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public int update(String sql, Map<String, Object> parameters) {
+        try (
+                Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(getOriginalSql(sql));
+        ) {
+            log.debug("query : {}", sql);
+            setQueryParameters(sql, pstmt, parameters);
+            return pstmt.executeUpdate();
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Map<String, Object> parameters) {
+        try (
+                Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(getOriginalSql(sql));
+        ) {
+            setQueryParameters(sql, pstmt, parameters);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                log.debug("query : {}", sql);
+
+                T result = null;
+                if (rs.next()) {
+                    result = rowMapper.mapRow(rs, rs.getRow());
+                }
+
+                verifyResultRowSize(rs, 1);
+
+                if (result == null) {
+                    throw new SQLException("조회결과가업서!");
+                }
+
+                return result;
+            }
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void verifyResultRowSize(final ResultSet rs, final int rowSize) throws SQLException {
+        rs.last();
+        if (rowSize < rs.getRow()) {
+            throw new SQLException(String.format("결과가 1개인 줄 알았는데, %d개 나왔서!", rs.getRow()));
+            /**
+             * 예외 원문 : Incorrect result size: expected 1, actual n
+             */
+        }
+    }
+
+    public <T> List<T> query(String sql, RowMapper<T> rowMapper, Map<String, Object> parameters) {
+        try (
+                Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(getOriginalSql(sql));
+        ) {
+            setQueryParameters(sql, pstmt, parameters);
+
+            try (ResultSet rs = pstmt.executeQuery();) {
+                log.debug("query : {}", sql);
+
+                final List<T> results = new ArrayList<>();
+                while (rs.next()) {
+                    results.add(rowMapper.mapRow(rs, rs.getRow()));
+                }
+                return results;
+            }
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void setQueryParameters(final String sql,
+                                    final PreparedStatement pstmt,
+                                    final Map<String, Object> parameters
+    ) throws SQLException {
+        final List<String> parameterNames = getQueryParameters(sql);
+
+        for (int index = 0; index < parameterNames.size(); index++) {
+            final String parameter = parameterNames.get(index);
+            if (parameters.get(parameter) == null) {
+                throw new DataAccessException(String.format("쿼리 파라미터를 빼먹었서 : %s", parameter));
+            }
+            pstmt.setObject(index + 1, parameters.get(parameter));
+        }
+    }
+
+    private static List<String> getQueryParameters(final String sql) {
+        Pattern pattern = Pattern.compile(":(\\w+)");
+        Matcher matcher = pattern.matcher(sql);
+
+        final List<String> queryParameters = new ArrayList<>();
+        while (matcher.find()) {
+            queryParameters.add(matcher.group(1)); // 그룹 1은 단어 부분을 나타냅니다.
+        }
+
+        return queryParameters;
+    }
+
+
+    private String getOriginalSql(final String sql) {
+        return sql.replaceAll(":\\w+", "?");
+    }
+}

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -1,5 +1,0 @@
-package nextstep.jdbc;
-
-class JdbcTemplateTest {
-
-}

--- a/jdbc/src/test/java/org/springframework/dao/SQLExceptionTranslatorTest.java
+++ b/jdbc/src/test/java/org/springframework/dao/SQLExceptionTranslatorTest.java
@@ -17,7 +17,7 @@ class SQLExceptionTranslatorTest {
         try {
             throw new SQLTimeoutException();
         } catch (SQLException e) {
-            SQLExceptionTranslator.translate(e);
+            throw SQLExceptionTranslator.translate(e);
         }
     }
 }

--- a/jdbc/src/test/java/org/springframework/dao/SQLExceptionTranslatorTest.java
+++ b/jdbc/src/test/java/org/springframework/dao/SQLExceptionTranslatorTest.java
@@ -1,0 +1,23 @@
+package org.springframework.dao;
+
+import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SQLExceptionTranslatorTest {
+
+    @Test
+    void translateException() {
+        Assertions.assertThatThrownBy(this::doThrow)
+                .isInstanceOf(org.springframework.dao.SQLTimeoutException.class);
+    }
+
+    private void doThrow() {
+        try {
+            throw new SQLTimeoutException();
+        } catch (SQLException e) {
+            SQLExceptionTranslator.translate(e);
+        }
+    }
+}


### PR DESCRIPTION
안녕하세요~!
1단계에서 받았던 피드백을 반영하면서 2단계 리팩토링을 진행했습니다.

2단계에서 추상적으로 적혀있던 `어떤 동작을 라이브러리로 만들까?` 부분에서
제가 신경써서 적용한 항목은 `SQL문의 매개변수와 값 설정`과 `예외 처리`입니다.

### SQL문의 매개변수와 값 설정
실행하려는 SQL의 파라미터로 '?'을 사용하고, 파라미터 순서에 맞게 값을 적용하는 기존의 방식은
파라미터 순서가 변경되면 깨질 수 있다는 문제가 있었습니다.

그래서
'?' 대신 ':name'같은 namedParameter를 사용한 SQL문을 작성하고
값을 적용하는 방식도 파라미터 순서에 상관없이 해당하는 이름에 정확히 매핑될 수 있도록 개선한
NamedParameterJdbcTemplate을 만들어 보았어요!

그런데 JdbcTemplate과 NamedParameterJdbcTemplate을 상속관계나 인터페이스를 통해 일원화하려 하니
호출하는 메서드의 형태가 완전히 달라서 다형성 적용을 할 수가 없더라구요 🥹
그래서 JdbcTemplate를 사용하는 UserDao와 NamedParameterJdbcTemplate를 사용하는 UserDao 이렇게 두 개의 UserDao가 나왔습니다.

### 예외 처리
CheckedException인 SQLException을 UnCheckedException인 DataAccessException으로 바꾸기 위해 SqlExceptionTranslator를 만들어 도입했어요.

간편하게 구현하려면 그냥 throw new DataAccessExcepton(SqlException) 하면 되지만,
실제 스프링 프레임워크의 예외 변경 형태를 보니
각각의 SQLException마다 1:1로 매핑되는 DataAccessException 구현체를 만들어 던지더라구요.

그래서 번거롭지만 SQLException의 모든 구현체에 해당하는 커스텀 예외 클래스를 만들고,
발생한 SQLException과 일치하는 커스텀 예외를 던져주도록 구현해 보았습니다!

---

이 이상은 어떻게 리팩토링하면 좋을지 모르겠어요 🥹 많은 피드백 주시면 감사드리겠습니다