### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 지토(김지민) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -1,5 +1,6 @@
 package com.techcourse.dao;
 
+import com.techcourse.dao.exception.UserNotFoundException;
 import com.techcourse.domain.User;
 import java.util.List;
 import javax.sql.DataSource;
@@ -47,12 +48,14 @@ public class UserDao {
     public User findById(final Long id) {
         final String sql = "select id, account, password, email from users where id = ?";
 
-        return jdbcTemplate.queryForObject(sql, userRowMapper, id);
+        return jdbcTemplate.queryForObject(sql, userRowMapper, id)
+                           .orElseThrow(() -> new UserNotFoundException("지정한 id에 대한 User를 찾을 수 없습니다."));
     }
 
     public User findByAccount(final String account) {
         final String sql = "select id, account, password, email from users where account = ?";
 
-        return jdbcTemplate.queryForObject(sql, userRowMapper, account);
+        return jdbcTemplate.queryForObject(sql, userRowMapper, account)
+                           .orElseThrow(() -> new UserNotFoundException("지정한 account에 대한 User를 찾을 수 없습니다."));
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -9,8 +9,7 @@ import org.springframework.jdbc.core.RowMapper;
 
 public class UserDao {
 
-    private final JdbcTemplate jdbcTemplate;
-    private final RowMapper<User> userRowMapper = resultSet -> {
+    private static final RowMapper<User> userRowMapper = resultSet -> {
         final Long id = resultSet.getLong("id");
         final String account = resultSet.getString("account");
         final String password = resultSet.getString("password");
@@ -18,6 +17,8 @@ public class UserDao {
 
         return new User(id, account, password, email);
     };
+
+    private final JdbcTemplate jdbcTemplate;
 
     public UserDao(final DataSource dataSource) {
         this.jdbcTemplate = new JdbcTemplate(dataSource);

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -31,32 +31,32 @@ public class UserDao {
     public void insert(final User user) {
         final String sql = "insert into users (account, password, email) values (?, ?, ?)";
 
-        jdbcTemplate.query(sql, user.getAccount(), user.getPassword(), user.getEmail());
+        jdbcTemplate.executeQuery(sql, user.getAccount(), user.getPassword(), user.getEmail());
     }
 
     public void update(final User user) {
         final String sql = "update users set (account, password, email) = (?, ?, ?) where id = ?";
 
-        jdbcTemplate.query(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
+        jdbcTemplate.executeQuery(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
     }
 
     public List<User> findAll() {
         final String sql = "select id, account, password, email from users";
 
-        return jdbcTemplate.queryForList(sql, userRowMapper);
+        return jdbcTemplate.executeQueryForList(sql, userRowMapper);
     }
 
     public User findById(final Long id) {
         final String sql = "select id, account, password, email from users where id = ?";
 
-        return jdbcTemplate.queryForObject(sql, userRowMapper, id)
+        return jdbcTemplate.executeQueryForObject(sql, userRowMapper, id)
                            .orElseThrow(() -> new UserNotFoundException("지정한 id에 대한 User를 찾을 수 없습니다."));
     }
 
     public User findByAccount(final String account) {
         final String sql = "select id, account, password, email from users where account = ?";
 
-        return jdbcTemplate.queryForObject(sql, userRowMapper, account)
+        return jdbcTemplate.executeQueryForObject(sql, userRowMapper, account)
                            .orElseThrow(() -> new UserNotFoundException("지정한 account에 대한 User를 찾을 수 없습니다."));
     }
 }

--- a/app/src/main/java/com/techcourse/dao/exception/UserNotFoundException.java
+++ b/app/src/main/java/com/techcourse/dao/exception/UserNotFoundException.java
@@ -1,0 +1,8 @@
+package com.techcourse.dao.exception;
+
+public class UserNotFoundException extends IllegalArgumentException {
+
+    public UserNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -6,20 +6,30 @@ import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 class UserDaoTest {
 
     private UserDao userDao;
+    private User persistUser;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
 
         userDao = new UserDao(DataSourceConfig.getInstance());
         final User user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
+        persistUser = userDao.findByAccount("gugu");
+    }
+
+    @AfterEach
+    void tearDown() {
+        final JdbcTemplate jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        jdbcTemplate.executeQuery("DELETE FROM users");
     }
 
     @Test
@@ -31,7 +41,7 @@ class UserDaoTest {
 
     @Test
     void findById() {
-        final User user = userDao.findById(1L);
+        final User user = userDao.findById(persistUser.getId());
 
         assertThat(user.getAccount()).isEqualTo("gugu");
     }
@@ -50,7 +60,7 @@ class UserDaoTest {
         final User user = new User(account, "password", "hkkang@woowahan.com");
         userDao.insert(user);
 
-        final User actual = userDao.findById(2L);
+        final User actual = userDao.findByAccount(account);
 
         assertThat(actual.getAccount()).isEqualTo(account);
     }
@@ -58,12 +68,12 @@ class UserDaoTest {
     @Test
     void update() {
         final String newPassword = "password99";
-        final User user = userDao.findById(1L);
+        final User user = userDao.findById(persistUser.getId());
         user.changePassword(newPassword);
 
         userDao.update(user);
 
-        final User actual = userDao.findById(1L);
+        final User actual = userDao.findById(persistUser.getId());
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -33,7 +33,7 @@ public class JdbcTemplate {
     ) {
         return preparedStatementTemplate.execute(
                 connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
-                preparedStatement -> resultSetTemplate.resultSetExecute(
+                preparedStatement -> resultSetTemplate.execute(
                         preparedStatement,
                         resultSet -> {
                             if (!resultSet.next()) {
@@ -59,7 +59,7 @@ public class JdbcTemplate {
     ) {
         return preparedStatementTemplate.execute(
                 connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
-                preparedStatement -> resultSetTemplate.resultSetExecute(
+                preparedStatement -> resultSetTemplate.execute(
                         preparedStatement,
                         resultSet -> {
                             final List<T> result = new ArrayList<>();

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -18,14 +18,18 @@ public class JdbcTemplate {
         this.resultSetTemplate = new ResultSetTemplate();
     }
 
-    public int query(final String sql, final Object... statements) {
+    public int executeQuery(final String sql, final Object... statements) {
         return preparedStatementTemplate.execute(
                 connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
                 PreparedStatement::executeUpdate
         );
     }
 
-    public <T> Optional<T> queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... statements) {
+    public <T> Optional<T> executeQueryForObject(
+            final String sql,
+            final RowMapper<T> rowMapper,
+            final Object... statements
+    ) {
         return preparedStatementTemplate.execute(
                 connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
                 preparedStatement -> resultSetTemplate.resultSetExecute(
@@ -41,7 +45,11 @@ public class JdbcTemplate {
         );
     }
 
-    public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper, final Object... statements) {
+    public <T> List<T> executeQueryForList(
+            final String sql,
+            final RowMapper<T> rowMapper,
+            final Object... statements
+    ) {
         return preparedStatementTemplate.execute(
                 connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
                 preparedStatement -> resultSetTemplate.resultSetExecute(

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1,86 +1,71 @@
 package org.springframework.jdbc.core;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import javax.sql.DataSource;
-import org.springframework.jdbc.core.exception.JdbcTemplateException;
 
 public class JdbcTemplate {
 
     private static final int START_STATEMENT_INDEX = 1;
 
-    private final DataSource dataSource;
+    private final PreparedStatementTemplate preparedStatementTemplate;
+    private final ResultSetTemplate resultSetTemplate;
 
     public JdbcTemplate(final DataSource dataSource) {
-        this.dataSource = dataSource;
+        this.preparedStatementTemplate = new PreparedStatementTemplate(dataSource);
+        this.resultSetTemplate = new ResultSetTemplate();
     }
 
     public int query(final String sql, final Object... statements) {
-        try (
-                final Connection connection = dataSource.getConnection();
-                final PreparedStatement preparedStatement = processPreparedStatement(connection, sql, statements)
-        ) {
-            return preparedStatement.executeUpdate();
-        } catch (final SQLException e) {
-            throw new JdbcTemplateException(e);
-        }
+        return preparedStatementTemplate.execute(
+                connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
+                PreparedStatement::executeUpdate
+        );
     }
 
-    public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... statements) {
-        try (
-                final Connection connection = dataSource.getConnection();
-                final PreparedStatement preparedStatement = processPreparedStatement(connection, sql, statements);
-                final ResultSet resultSet = preparedStatement.executeQuery()
-        ) {
-            if (resultSet.next()) {
-                return rowMapper.mapRow(resultSet);
-            }
+    public <T> Optional<T> queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... statements) {
+        return preparedStatementTemplate.execute(
+                connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
+                preparedStatement -> resultSetTemplate.resultSetExecute(
+                        preparedStatement,
+                        resultSet -> {
+                            if (resultSet.next()) {
+                                return Optional.of(rowMapper.mapRow(resultSet));
+                            }
 
-            return null;
-        } catch (final SQLException e) {
-            throw new JdbcTemplateException(e);
-        }
+                            return Optional.empty();
+                        }
+                )
+        );
     }
 
     public <T> List<T> queryForList(final String sql, final RowMapper<T> rowMapper, final Object... statements) {
-        try (
-                final Connection connection = dataSource.getConnection();
-                final PreparedStatement preparedStatement = processPreparedStatement(connection, sql, statements);
-                final ResultSet resultSet = preparedStatement.executeQuery()
-        ) {
-            final List<T> result = new ArrayList<>();
+        return preparedStatementTemplate.execute(
+                connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
+                preparedStatement -> resultSetTemplate.resultSetExecute(
+                        preparedStatement,
+                        resultSet -> {
+                            final List<T> result = new ArrayList<>();
 
-            while (resultSet.next()) {
-                result.add(rowMapper.mapRow(resultSet));
+                            while (resultSet.next()) {
+                                result.add(rowMapper.mapRow(resultSet));
+                            }
+
+                            return result;
+                        }
+                )
+        );
+    }
+
+    private PreparedStatementBinder bindStatements() {
+        return (preparedStatement, statements) -> {
+            for (int i = START_STATEMENT_INDEX; i < statements.length + 1; i++) {
+                preparedStatement.setObject(i, statements[i - START_STATEMENT_INDEX]);
             }
 
-            return result;
-        } catch (final SQLException e) {
-            throw new JdbcTemplateException(e);
-        }
-    }
-
-    private PreparedStatement processPreparedStatement(
-            final Connection connection,
-            final String sql,
-            final Object[] statements
-    ) throws SQLException {
-        final PreparedStatement preparedStatement = connection.prepareStatement(sql);
-
-        bindStatements(preparedStatement, statements);
-        return preparedStatement;
-    }
-
-    private void bindStatements(
-            final PreparedStatement preparedStatement,
-            final Object[] statements
-    ) throws SQLException {
-        for (int i = START_STATEMENT_INDEX; i < statements.length + 1; i++) {
-            preparedStatement.setObject(i, statements[i - START_STATEMENT_INDEX]);
-        }
+            return preparedStatement;
+        };
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementBinder.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementBinder.java
@@ -1,0 +1,10 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementBinder {
+
+    PreparedStatement bind(final PreparedStatement preparedStatement, final Object... statements) throws SQLException;
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCreator.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCreator.java
@@ -1,0 +1,11 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementCreator {
+
+    PreparedStatement create(final Connection connection) throws SQLException;
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
@@ -1,0 +1,10 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementExecutor<T> {
+
+    T execute(final PreparedStatement preparedStatement) throws SQLException;
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementTemplate.java
@@ -4,7 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import javax.sql.DataSource;
-import org.springframework.jdbc.core.exception.JdbcTemplateException;
+import org.springframework.jdbc.core.exception.PreparedStatementTemplateException;
 
 public class PreparedStatementTemplate {
 
@@ -24,7 +24,7 @@ public class PreparedStatementTemplate {
         ) {
             return executor.execute(preparedStatement);
         } catch (final SQLException e) {
-            throw new JdbcTemplateException(e);
+            throw new PreparedStatementTemplateException(e);
         }
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementTemplate.java
@@ -1,0 +1,30 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.exception.JdbcTemplateException;
+
+public class PreparedStatementTemplate {
+
+    private final DataSource dataSource;
+
+    public PreparedStatementTemplate(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> T execute(
+            final PreparedStatementCreator creator,
+            final PreparedStatementExecutor<T> executor
+    ) {
+        try (
+                final Connection connection = dataSource.getConnection();
+                final PreparedStatement preparedStatement = creator.create(connection)
+        ) {
+            return executor.execute(preparedStatement);
+        } catch (final SQLException e) {
+            throw new JdbcTemplateException(e);
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ResultSetMapper.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ResultSetMapper.java
@@ -1,0 +1,10 @@
+package org.springframework.jdbc.core;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface ResultSetMapper<T> {
+
+    T execute(final ResultSet resultSet) throws SQLException;
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ResultSetTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ResultSetTemplate.java
@@ -1,0 +1,20 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.exception.ResultSetTemplateException;
+
+public class ResultSetTemplate {
+
+    public <T> T resultSetExecute(
+            final PreparedStatement preparedStatement,
+            final ResultSetMapper<T> resultSetMapper
+    ) {
+        try (final ResultSet resultSet = preparedStatement.executeQuery()) {
+            return resultSetMapper.execute(resultSet);
+        } catch (final SQLException e) {
+            throw new ResultSetTemplateException(e);
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ResultSetTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ResultSetTemplate.java
@@ -7,7 +7,7 @@ import org.springframework.jdbc.core.exception.ResultSetTemplateException;
 
 public class ResultSetTemplate {
 
-    public <T> T resultSetExecute(
+    public <T> T execute(
             final PreparedStatement preparedStatement,
             final ResultSetMapper<T> resultSetMapper
     ) {

--- a/jdbc/src/main/java/org/springframework/jdbc/core/exception/MultipleDataAccessException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/exception/MultipleDataAccessException.java
@@ -1,0 +1,8 @@
+package org.springframework.jdbc.core.exception;
+
+public class MultipleDataAccessException extends RuntimeException {
+
+    public MultipleDataAccessException(final String message) {
+        super(message);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/exception/PreparedStatementTemplateException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/exception/PreparedStatementTemplateException.java
@@ -1,0 +1,8 @@
+package org.springframework.jdbc.core.exception;
+
+public class PreparedStatementTemplateException extends RuntimeException {
+
+    public PreparedStatementTemplateException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/exception/ResultSetTemplateException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/exception/ResultSetTemplateException.java
@@ -1,0 +1,8 @@
+package org.springframework.jdbc.core.exception;
+
+public class ResultSetTemplateException extends RuntimeException {
+
+    public ResultSetTemplateException(final Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
안녕하세요 오리 
추석 연휴 잘 지내고 계신가요? 
저는 뭐...집에서 코딩이나 했습니다 

---

리뷰 반영의 경우 `JdbcTemplate 메서드 네이밍 변경 & userRowMapper static 필드화`를 적용했습니다
메서드 네이밍...참 어려운 것 같습니다

---

이번 step2에서는 뭘 해야하나 좀 감이 안잡혔습니다 
그래서 고민좀 하다가 힌트랑 `transaction.stage1.jdbc` 패키지의 있는 내용을 살짝 봤는데 함수형 인터페이스를 활용해서 코드의 중복을 없애는 느낌인 것 같더라고요..?
저는 이전 step1 정도가 코드의 중복은 있을지언정 가독성은 더 좋다고 생각해서 상상도 못하고 있었는데 좀 당황스러웠습니다 
아무튼 코드의 중복(특히 try-with-resource 파트)을 없애는 것이 2단계 미션에서의 목표라고 생각해서 함수형 인터페이스와 템플릿 콜백 패턴을 사용해봤습니다

JdbcTemplate, PreparedStatementTemplate, ResultSetTemplate 이런 식으로 시리즈 느낌이 나도록 처리했습니다

JdbcTemplate은 Connection과 PreparedStatement에 대한 자원을 관리하는 PreparedStatementTemplate.execute() 메서드만 호출하도록 했습니다 
PreparedStatement에서 ResultSet에서 조회 결과를 꺼내야 하는 경우는 ResultSet에 대한 자원을 관리하는 ResultSetTemplate.execute()만 호출하도록 했습니다

각각의 템플릿 클래스에서 발생하는 예외는 별도로 분리했습니다 

---

추가적으로 결과 단일 조회 메서드에서 여러 결과가 조회된 경우 예외를 발생시키도록 예외 로직을 추가했고, 이로 인해 UserDaoTest 코드를 살짝 리펙토링을 진행했습니다

---

이정도입니다 
남은 연휴도 잘 보내시길 바랍니다 
그런 의미로 리뷰는 천천히...푹 쉬시다가 해주시면 감사하겠습니다 
아무튼 리뷰 잘 부탁드립니다  