### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 로이스(원태연) 미션 제출합니다.

### DIFF
--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -1,17 +1,19 @@
 package com.techcourse.dao;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 class UserDaoTest {
 
     private UserDao userDao;
+    private User testUser;
 
     @BeforeEach
     void setup() {
@@ -20,6 +22,13 @@ class UserDaoTest {
         userDao = new UserDao(jdbcTemplate);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
+        testUser = userDao.findByAccount("gugu");
+    }
+
+    @AfterEach
+    void clear() {
+        final var jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        jdbcTemplate.update("DELETE FROM users");
     }
 
     @Test
@@ -34,14 +43,14 @@ class UserDaoTest {
 
     @Test
     void findById() {
-        final var user = userDao.findById(1L);
+        final var user = userDao.findById(testUser.getId());
 
         assertThat(user.getAccount()).isEqualTo("gugu");
     }
 
     @Test
     void findByIdShouldBeNull() {
-        final var nullableUser = userDao.findById(3L);
+        final var nullableUser = userDao.findById(100L);
 
         assertThat(nullableUser).isNull();
     }
@@ -62,7 +71,7 @@ class UserDaoTest {
         userDao.insert(user);
 
         // when
-        final var actual = userDao.findById(2L);
+        final var actual = userDao.findByAccount("insert-gugu");
 
         // then
         assertThat(actual.getAccount()).isEqualTo(account);
@@ -71,12 +80,12 @@ class UserDaoTest {
     @Test
     void update() {
         final var newPassword = "password99";
-        final var user = userDao.findById(1L);
+        final var user = userDao.findByAccount("gugu");
         user.changePassword(newPassword);
 
         userDao.update(user);
 
-        final var actual = userDao.findById(1L);
+        final var actual = userDao.findByAccount("gugu");
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -49,13 +49,6 @@ class UserDaoTest {
     }
 
     @Test
-    void findByIdShouldBeNull() {
-        final var nullableUser = userDao.findById(100L);
-
-        assertThat(nullableUser).isNull();
-    }
-
-    @Test
     void findByAccount() {
         final var account = "gugu";
         final var user = userDao.findByAccount(account);

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -5,7 +5,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,13 +26,15 @@ public class JdbcTemplate {
         );
     }
 
-    @Nullable
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
         List<T> results = preparedStatementExecutor.execute(
                 getPreparedStatementCreator(sql, args),
                 preparedStatement -> mappingQueryResult(preparedStatement, rowMapper)
         );
-        return results.isEmpty() ? null : results.get(0);
+        if (results.size() != 1) {
+            throw new IllegalStateException("1개의 결과만 반환 해야 합니다.");
+        }
+        return results.get(0);
     }
 
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... args) {

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -5,6 +5,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,18 +27,20 @@ public class JdbcTemplate {
         );
     }
 
+    @Nullable
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
-        List<T> results = preparedStatementExecutor.execute(
-                getPreparedStatementCreator(sql, args),
-                preparedStatement -> mappingQueryResult(preparedStatement, rowMapper)
-        );
-        if (results.size() != 1) {
+        List<T> results = queryResults(sql, rowMapper, args);
+        if (results.size() > 1) {
             throw new IllegalStateException("1개의 결과만 반환 해야 합니다.");
         }
-        return results.get(0);
+        return results.isEmpty() ? null : results.get(0);
     }
 
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... args) {
+        return queryResults(sql, rowMapper, args);
+    }
+
+    private <T> List<T> queryResults(final String sql, final RowMapper<T> rowMapper, final Object[] args) {
         return preparedStatementExecutor.execute(
                 getPreparedStatementCreator(sql, args),
                 preparedStatement -> mappingQueryResult(preparedStatement, rowMapper)

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -14,11 +14,9 @@ public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
 
-    private final DataSource dataSource;
     private final PreparedStatementExecutor preparedStatementExecutor;
 
     public JdbcTemplate(final DataSource dataSource) {
-        this.dataSource = dataSource;
         this.preparedStatementExecutor = new PreparedStatementExecutor(dataSource);
     }
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCaller.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCaller.java
@@ -6,5 +6,5 @@ import java.sql.SQLException;
 @FunctionalInterface
 public interface PreparedStatementCaller<T> {
 
-    T execute(final PreparedStatement preparedStatement) throws SQLException;
+    T call(final PreparedStatement preparedStatement) throws SQLException;
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCaller.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCaller.java
@@ -1,0 +1,10 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementCaller<T> {
+
+    T execute(final PreparedStatement preparedStatement) throws SQLException;
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCreator.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCreator.java
@@ -1,0 +1,11 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementCreator {
+
+    PreparedStatement createPreparedStatement(final Connection conn) throws SQLException;
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
@@ -13,12 +13,13 @@ public class PreparedStatementExecutor {
         this.dataSource = dataSource;
     }
 
-    public void execute(
-            final PreparedStatementCreator preparedStatementCreator
+    public <T> T execute(
+            final PreparedStatementCreator preparedStatementCreator,
+            final PreparedStatementCaller<T> preparedStatementCaller
     ) {
         try (final Connection conn = dataSource.getConnection();
              final PreparedStatement preparedStatement = preparedStatementCreator.createPreparedStatement(conn)) {
-            preparedStatement.executeUpdate();
+            return preparedStatementCaller.execute(preparedStatement);
         } catch (final SQLException e) {
             throw new RuntimeException(e);
         }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
@@ -1,0 +1,26 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+public class PreparedStatementExecutor {
+
+    private final DataSource dataSource;
+
+    public PreparedStatementExecutor(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void execute(
+            final PreparedStatementCreator preparedStatementCreator
+    ) {
+        try (final Connection conn = dataSource.getConnection();
+             final PreparedStatement preparedStatement = preparedStatementCreator.createPreparedStatement(conn)) {
+            preparedStatement.executeUpdate();
+        } catch (final SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
@@ -19,7 +19,7 @@ public class PreparedStatementExecutor {
     ) {
         try (final Connection conn = dataSource.getConnection();
              final PreparedStatement preparedStatement = preparedStatementCreator.createPreparedStatement(conn)) {
-            return preparedStatementCaller.execute(preparedStatement);
+            return preparedStatementCaller.call(preparedStatement);
         } catch (final SQLException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
안녕하세요, 아벨!
2단계 리팩토링 후 리뷰 요청 드립니다.
`jdbcTemplate`에서 `try-with-resource` 부분의 중복을 제거하기 위해 공통으로 실행되는 로직을 함수형 인터페이스로 분리 한 뒤, `PreparedStatementExecutor`에서 실행 되도록 구성해보았습니다.
중복되는 로직 제거에 신경 썼는데 구조가 조금 어색한 것 같기도 하네요..!
리뷰 잘 부탁드립니다~!

</br></br>
이전 질문에 대해서 간단하게 답변 남겨 둘게요!
- `전 개인적으로 여러 메서드에서 공용으로 쓰이는 setAllArguments 메서드 같은 경우는 가장 아래쪽에 메서드를 배치하는 편인데, 로이스는 처음으로 호출된 메서드 바로 밑에 두시나보군요. 어떤 기준이 있는 것인지 궁금하네요!`
한번만 호출되면 바로 아래에 두는 편인데, 공통으로 사용 되는 성격의 메서드는 아래에 위치시키는게 좋아보이네요! 반영했습니다!


- `var를 쓰시면서 로이스가 체감한 장단점이 있다면 어떤 것들이 있을 지 궁금합니다 :)`
가독성이 높아지는게 큰 것 같아요. 코드 길이가 짧아져서 반환타입이 아닌 `statement`에 집중이 잘 되더라구요. 단점은 다른사람이 var로 작성한 코드를 이해하는 데 시간이 좀 걸리는 것 같습니다
