### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 쥬니(전정준) 미션 제출합니다.

### DIFF
--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -7,7 +7,6 @@ import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -40,9 +40,9 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> List<T> query(String sql, RowMapper<T> rowMapper) {
+    public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... args) {
         try (Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = conn.prepareStatement(sql);
+                PreparedStatement pstmt = getQueryPstmtForObject(sql, conn, args);
                 ResultSet rs = pstmt.executeQuery()) {
 
             List<T> results = new ArrayList<>();

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -24,11 +24,11 @@ public class JdbcTemplate {
         return queryTemplate.query(sql, (resultSet -> mapResultToList(resultSet, rowMapper)), args);
     }
 
-    private <T> List<T> mapResultToList(ResultSet rs, RowMapper<T> rowMapper) throws SQLException {
+    private <T> List<T> mapResultToList(ResultSet resultSet, RowMapper<T> rowMapper) throws SQLException {
         List<T> results = new ArrayList<>();
 
-        while (rs.next()) {
-            T result = rowMapper.mapRow(rs);
+        while (resultSet.next()) {
+            T result = rowMapper.mapRow(resultSet);
 
             results.add(result);
         }
@@ -40,11 +40,11 @@ public class JdbcTemplate {
         return queryTemplate.query(sql, resultSet -> mapResultToObject(resultSet, rowMapper), args);
     }
 
-    private <T> T mapResultToObject(ResultSet rs, RowMapper<T> rowMapper) throws SQLException {
-        if (rs.next()) {
-            T result = rowMapper.mapRow(rs);
+    private <T> T mapResultToObject(ResultSet resultSet, RowMapper<T> rowMapper) throws SQLException {
+        if (resultSet.next()) {
+            T result = rowMapper.mapRow(resultSet);
 
-            validateSingleResult(rs);
+            validateSingleResult(resultSet);
 
             return result;
         }
@@ -52,8 +52,8 @@ public class JdbcTemplate {
         throw new DataAccessException("Incorrect Result Size ! Result is null");
     }
 
-    private void validateSingleResult(ResultSet rs) throws SQLException {
-        if (rs.next()) {
+    private void validateSingleResult(ResultSet resultSet) throws SQLException {
+        if (resultSet.next()) {
             throw new DataAccessException("Incorrect Result Size ! Result  must be one");
         }
     }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -6,10 +6,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 
 public class JdbcTemplate {
 
@@ -30,7 +30,7 @@ public class JdbcTemplate {
             pstmt.executeUpdate();
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e);
         }
     }
 
@@ -56,7 +56,7 @@ public class JdbcTemplate {
             return results;
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e);
         }
     }
 
@@ -69,16 +69,16 @@ public class JdbcTemplate {
                 T result = rowMapper.mapRow(rs);
 
                 if (rs.next()) {
-                    throw new IllegalArgumentException("Incorrect Result Size ! Result  must be one");
+                    throw new DataAccessException("Incorrect Result Size ! Result  must be one");
                 }
 
                 return result;
             }
 
-            throw new NoSuchElementException("Incorrect Result Size ! Result is null");
+            throw new DataAccessException("Incorrect Result Size ! Result is null");
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e);
         }
     }
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -51,14 +51,14 @@ public class JdbcTemplate {
                 PreparedStatement pstmt = getInitializedPstmt(sql, conn, args);
                 ResultSet rs = pstmt.executeQuery()) {
 
-            return mapResultToList(rowMapper, rs);
+            return mapResultToList(rs, rowMapper);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new DataAccessException(e);
         }
     }
 
-    private <T> List<T> mapResultToList(RowMapper<T> rowMapper, ResultSet rs) throws SQLException {
+    private <T> List<T> mapResultToList(ResultSet rs, RowMapper<T> rowMapper) throws SQLException {
         List<T> results = new ArrayList<>();
 
         while (rs.next()) {
@@ -75,14 +75,14 @@ public class JdbcTemplate {
                 PreparedStatement pstmt = getInitializedPstmt(sql, conn, args);
                 ResultSet rs = pstmt.executeQuery()) {
 
-            return mapResultToObject(rowMapper, rs);
+            return mapResultToObject(rs, rowMapper);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new DataAccessException(e);
         }
     }
 
-    private <T> T mapResultToObject(RowMapper<T> rowMapper, ResultSet rs) throws SQLException {
+    private <T> T mapResultToObject(ResultSet rs, RowMapper<T> rowMapper) throws SQLException {
         if (rs.next()) {
             T result = rowMapper.mapRow(rs);
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -17,15 +17,11 @@ public class JdbcTemplate {
     }
 
     public void update(String sql, Object... args) {
-        queryTemplate.query(sql, PreparedStatement::executeUpdate, args);
+        queryTemplate.update(sql, PreparedStatement::executeUpdate, args);
     }
 
     public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... args) {
-        return queryTemplate.query(sql, (pstmt -> {
-            try(ResultSet rs = pstmt.executeQuery()){
-                return mapResultToList(rs, rowMapper);
-            }
-        }), args);
+        return queryTemplate.query(sql, (resultSet -> mapResultToList(resultSet, rowMapper)), args);
     }
 
     private <T> List<T> mapResultToList(ResultSet rs, RowMapper<T> rowMapper) throws SQLException {
@@ -41,11 +37,7 @@ public class JdbcTemplate {
     }
 
     public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... args) {
-        return queryTemplate.query(sql, (pstmt -> {
-            try(ResultSet rs = pstmt.executeQuery()){
-                return mapResultToObject(rs, rowMapper);
-            }
-        }), args);
+        return queryTemplate.query(sql, resultSet -> mapResultToObject(resultSet, rowMapper), args);
     }
 
     private <T> T mapResultToObject(ResultSet rs, RowMapper<T> rowMapper) throws SQLException {

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1,61 +1,31 @@
 package org.springframework.jdbc.core;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.sql.DataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 
 public class JdbcTemplate {
 
-    private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
-
-    private final DataSource dataSource;
+    private final QueryTemplate queryTemplate;
 
     public JdbcTemplate(DataSource dataSource) {
-        this.dataSource = dataSource;
+        this.queryTemplate = new QueryTemplate(dataSource);
     }
 
     public void update(String sql, Object... args) {
-        try (Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = getInitializedPstmt(sql, conn, args)) {
-
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e);
-        }
-    }
-
-    private PreparedStatement getInitializedPstmt(String sql, Connection conn, Object... args) throws SQLException {
-        PreparedStatement pstmt = conn.prepareStatement(sql);
-
-        initializePstmtArgs(pstmt, args);
-
-        return pstmt;
-    }
-
-    private void initializePstmtArgs(PreparedStatement pstmt, Object... args) throws SQLException {
-        for (int i = 0; i < args.length; i++) {
-            pstmt.setObject(i + 1, args[i]);
-        }
+        queryTemplate.query(sql, PreparedStatement::executeUpdate, args);
     }
 
     public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... args) {
-        try (Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = getInitializedPstmt(sql, conn, args);
-                ResultSet rs = pstmt.executeQuery()) {
-
-            return mapResultToList(rs, rowMapper);
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e);
-        }
+        return queryTemplate.query(sql, (pstmt -> {
+            try(ResultSet rs = pstmt.executeQuery()){
+                return mapResultToList(rs, rowMapper);
+            }
+        }), args);
     }
 
     private <T> List<T> mapResultToList(ResultSet rs, RowMapper<T> rowMapper) throws SQLException {
@@ -71,15 +41,11 @@ public class JdbcTemplate {
     }
 
     public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... args) {
-        try (Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = getInitializedPstmt(sql, conn, args);
-                ResultSet rs = pstmt.executeQuery()) {
-
-            return mapResultToObject(rs, rowMapper);
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e);
-        }
+        return queryTemplate.query(sql, (pstmt -> {
+            try(ResultSet rs = pstmt.executeQuery()){
+                return mapResultToObject(rs, rowMapper);
+            }
+        }), args);
     }
 
     private <T> T mapResultToObject(ResultSet rs, RowMapper<T> rowMapper) throws SQLException {

--- a/jdbc/src/main/java/org/springframework/jdbc/core/QueryExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/QueryExecutor.java
@@ -1,0 +1,10 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface QueryExecutor<T> {
+
+    T execute(PreparedStatement pstmt) throws SQLException;
+
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/QueryExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/QueryExecutor.java
@@ -3,6 +3,7 @@ package org.springframework.jdbc.core;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+@FunctionalInterface
 public interface QueryExecutor<T> {
 
     T execute(PreparedStatement pstmt) throws SQLException;

--- a/jdbc/src/main/java/org/springframework/jdbc/core/QueryTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/QueryTemplate.java
@@ -20,34 +20,36 @@ public class QueryTemplate {
     }
 
     public <T> T update(String sql, UpdateExecutor<T> executor, Object... args) {
-        try (Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = getInitializedPstmt(sql, conn, args)) {
-            return executor.execute(pstmt);
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = getInitializedPreparedStatement(sql, connection, args)) {
+            return executor.execute(preparedStatement);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new DataAccessException(e);
         }
     }
 
-    private PreparedStatement getInitializedPstmt(String sql, Connection conn, Object... args) throws SQLException {
-        PreparedStatement pstmt = conn.prepareStatement(sql);
+    private PreparedStatement getInitializedPreparedStatement(String sql, Connection connection, Object... args)
+            throws SQLException {
+        PreparedStatement preparedStatement = connection.prepareStatement(sql);
 
-        initializePstmtArgs(pstmt, args);
+        initializePreparedStatementArguments(preparedStatement, args);
 
-        return pstmt;
+        return preparedStatement;
     }
 
-    private void initializePstmtArgs(PreparedStatement pstmt, Object... args) throws SQLException {
+    private void initializePreparedStatementArguments(PreparedStatement preparedStatement, Object... args)
+            throws SQLException {
         for (int i = 0; i < args.length; i++) {
-            pstmt.setObject(i + 1, args[i]);
+            preparedStatement.setObject(i + 1, args[i]);
         }
     }
 
     public <T> T query(String sql, SelectExecutor<T> executor, Object... args) {
-        try (Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = getInitializedPstmt(sql, conn, args);
-                ResultSet rs = pstmt.executeQuery()) {
-            return executor.execute(rs);
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = getInitializedPreparedStatement(sql, connection, args);
+                ResultSet resultSet = preparedStatement.executeQuery()) {
+            return executor.execute(resultSet);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new DataAccessException(e);

--- a/jdbc/src/main/java/org/springframework/jdbc/core/QueryTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/QueryTemplate.java
@@ -1,0 +1,45 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+
+public class QueryTemplate {
+
+    private static final Logger log = LoggerFactory.getLogger(QueryTemplate.class);
+
+    private final DataSource dataSource;
+
+    public QueryTemplate(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> T query(String sql, QueryExecutor<T> executor, Object... args) {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = getInitializedPstmt(sql, conn, args)) {
+            return executor.execute(pstmt);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new DataAccessException(e);
+        }
+    }
+
+    private PreparedStatement getInitializedPstmt(String sql, Connection conn, Object... args) throws SQLException {
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+
+        initializePstmtArgs(pstmt, args);
+
+        return pstmt;
+    }
+
+    private void initializePstmtArgs(PreparedStatement pstmt, Object... args) throws SQLException {
+        for (int i = 0; i < args.length; i++) {
+            pstmt.setObject(i + 1, args[i]);
+        }
+    }
+
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/SelectExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/SelectExecutor.java
@@ -1,0 +1,11 @@
+package org.springframework.jdbc.core;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface SelectExecutor<T> {
+
+    T execute(ResultSet resultSet) throws SQLException;
+
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/UpdateExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/UpdateExecutor.java
@@ -6,6 +6,6 @@ import java.sql.SQLException;
 @FunctionalInterface
 public interface UpdateExecutor<T> {
 
-    T execute(PreparedStatement pstmt) throws SQLException;
+    T execute(PreparedStatement preparedStatement) throws SQLException;
 
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/UpdateExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/UpdateExecutor.java
@@ -4,7 +4,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 @FunctionalInterface
-public interface QueryExecutor<T> {
+public interface UpdateExecutor<T> {
 
     T execute(PreparedStatement pstmt) throws SQLException;
 

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,23 +26,27 @@ class JdbcTemplateTest {
     private DataSource dataSource;
     @Mock
     private PreparedStatement preparedStatement;
+    @Mock
+    private ResultSet rs;
     @InjectMocks
     private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
-    void setup(){
+    void setup() {
         MockitoAnnotations.openMocks(this);
     }
+
     @Test
     @DisplayName("try문에서 메서드 호출을 통해 변수를 초기화 해도 객체를 사용 후 반환한다.")
     void tryWithResourcesTest() throws SQLException {
         when(dataSource.getConnection()).thenReturn(connection);
         when(connection.prepareStatement(any())).thenReturn(preparedStatement);
-        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(preparedStatement.executeQuery()).thenReturn(rs);
+        when(rs.next()).thenReturn(false);
+        jdbcTemplate.query("Test Sql", null);
 
-        jdbcTemplate.update("Test Sql");
-
-        verify(preparedStatement,times(1)).close();
+        verify(preparedStatement, times(1)).close();
         verify(connection, times(1)).close();
+        verify(rs, times(1)).close();
     }
 }

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -26,8 +26,6 @@ class JdbcTemplateTest {
     private DataSource dataSource;
     @Mock
     private PreparedStatement preparedStatement;
-    @Mock
-    private ResultSet rs;
     @InjectMocks
     private JdbcTemplate jdbcTemplate;
 
@@ -41,12 +39,10 @@ class JdbcTemplateTest {
     void tryWithResourcesTest() throws SQLException {
         when(dataSource.getConnection()).thenReturn(connection);
         when(connection.prepareStatement(any())).thenReturn(preparedStatement);
-        when(preparedStatement.executeQuery()).thenReturn(rs);
-        when(rs.next()).thenReturn(false);
-        jdbcTemplate.query("Test Sql", null);
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        jdbcTemplate.update("Test Sql");
 
         verify(preparedStatement, times(1)).close();
         verify(connection, times(1)).close();
-        verify(rs, times(1)).close();
     }
 }

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -1,5 +1,47 @@
 package nextstep.jdbc;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.jdbc.core.JdbcTemplate;
+
 class JdbcTemplateTest {
 
+    @Mock
+    private Connection connection;
+    @Mock
+    private DataSource dataSource;
+    @Mock
+    private PreparedStatement preparedStatement;
+    @InjectMocks
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setup(){
+        MockitoAnnotations.openMocks(this);
+    }
+    @Test
+    @DisplayName("try문에서 메서드 호출을 통해 변수를 초기화 해도 객체를 사용 후 반환한다.")
+    void tryWithResourcesTest() throws SQLException {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(any())).thenReturn(preparedStatement);
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        jdbcTemplate.update("Test Sql");
+
+        verify(preparedStatement,times(1)).close();
+        verify(connection, times(1)).close();
+    }
 }

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -37,11 +37,15 @@ class JdbcTemplateTest {
     @Test
     @DisplayName("try문에서 메서드 호출을 통해 변수를 초기화 해도 객체를 사용 후 반환한다.")
     void tryWithResourcesTest() throws SQLException {
+        //given
         when(dataSource.getConnection()).thenReturn(connection);
         when(connection.prepareStatement(any())).thenReturn(preparedStatement);
         when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        //when
         jdbcTemplate.update("Test Sql");
 
+        //then
         verify(preparedStatement, times(1)).close();
         verify(connection, times(1)).close();
     }


### PR DESCRIPTION
안녕하세요 루카 ~! 2단계 구현해서 제출합니다 !

사실, 1단계와 크게 달라진 부분은 없는 것 같아요.. (힌트를 읽어봐도 이미 적용한 내용인 것 같아서 ㅠㅠ)
전반적인 리팩토링을 수행하면 될 것 같아서, 메서드 분리에 초점을 두었어요.
물론, 이마저도 크게 바뀐 건 없지만요 ㅎㅎㅎ

---

템플릿 메서드...를 도입해보았어요 ㅎㅎ 죄송합니다 루카 😗

한 가지 궁금한 점이 생겼어요 ㅎㅎ
```java
    public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... args) {
        return queryTemplate.query(sql, (pstmt -> {
            try(ResultSet rs = pstmt.executeQuery()){
                return mapResultToList(rs, rowMapper);
            }
        }), args);
    }
```
위 코드를 보면, ResultSet을 try-with-resources로 반환해주고 있는데요.
ResultSet의 코드 주석(?)을 확인해보면,
> A ResultSet object is automatically closed when the Statement object that generated it is closed, re-executed, or used to retrieve the next result from a sequence of multiple results.

와 같이 나와있어요. 즉, PreparedStatement가 반환되면 ResultSet도 함께 반환되어야할 것 같은데, 실제로는 그렇지 않더라구요.

루카는 혹시 이유를 아시나요 ㅎㅎ~?