### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 코코닥(이승용) 미션 제출합니다. 

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -12,12 +12,12 @@ import org.springframework.jdbc.core.RowMapper;
 public class UserDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserDao.class);
+    private static final RowMapper<User> ROW_MAPPER = (resultSet -> new User(resultSet.getLong("id"),
+                                                                             resultSet.getString("account"),
+                                                                             resultSet.getString("password"),
+                                                                             resultSet.getString("email")));
 
     private final JdbcTemplate jdbcTemplate;
-    private final RowMapper<User> rowMapper = (resultSet -> new User(resultSet.getLong("id"),
-                                                                     resultSet.getString("account"),
-                                                                     resultSet.getString("password"),
-                                                                     resultSet.getString("email")));
 
     public UserDao(final DataSource dataSource) {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
@@ -46,18 +46,18 @@ public class UserDao {
 
     public List<User> findAll() {
         final String sql = "SELECT id, account, password, email FROM users";
-        return jdbcTemplate.query(sql, rowMapper);
+        return jdbcTemplate.query(sql, ROW_MAPPER);
     }
 
     public User findById(final Long id) {
         final String sql = "select id, account, password, email from users where id = ?";
-        return jdbcTemplate.queryForObject(sql, rowMapper, id)
+        return jdbcTemplate.queryForObject(sql, ROW_MAPPER, id)
                            .orElseThrow(() -> new NoSuchElementException("Not Found"));
     }
 
     public User findByAccount(final String account) {
         final String sql = "SELECT id, account, password, email FROM users WHERE account = ?";
-        return jdbcTemplate.queryForObject(sql, rowMapper, account)
+        return jdbcTemplate.queryForObject(sql, ROW_MAPPER, account)
                            .orElseThrow(() -> new NoSuchElementException("Not Found"));
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 
 public class JdbcTemplate {
 
@@ -31,7 +32,7 @@ public class JdbcTemplate {
 
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e.getMessage(), e);
         }
     }
 
@@ -58,7 +59,7 @@ public class JdbcTemplate {
 
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e.getMessage(), e);
         }
     }
 
@@ -76,7 +77,7 @@ public class JdbcTemplate {
 
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e.getMessage(), e);
         }
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1,83 +1,46 @@
 package org.springframework.jdbc.core;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.DataAccessException;
 
 public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
 
-    private final DataSource dataSource;
+    private final PreparedStatementExecutor preparedStatementExecutor;
 
     public JdbcTemplate(final DataSource dataSource) {
-        this.dataSource = dataSource;
+        this.preparedStatementExecutor = new PreparedStatementExecutor(dataSource);
     }
 
     public void update(final String sql, final Object... objects) {
-        try (final Connection connection = dataSource.getConnection();
-             final PreparedStatement preparedStatement = prepareStatementWithBindingQuery(connection.prepareStatement(sql), objects)) {
-
-            log.debug("query : {}", sql);
-
-            preparedStatement.executeUpdate();
-
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e.getMessage(), e);
-        }
-    }
-
-    private PreparedStatement prepareStatementWithBindingQuery(final PreparedStatement preparedStatement, final Object... objects) throws SQLException {
-        for (int i = 0; i < objects.length; i++) {
-            preparedStatement.setObject(i + 1, objects[i]);
-        }
-        return preparedStatement;
+        preparedStatementExecutor.execute(PreparedStatement::executeUpdate, sql, objects);
     }
 
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... objects) {
-        try (final Connection connection = dataSource.getConnection();
-             final PreparedStatement preparedStatement = prepareStatementWithBindingQuery(connection.prepareStatement(sql), objects);
-             final ResultSet resultSet = preparedStatement.executeQuery()) {
-
+        return preparedStatementExecutor.execute(preparedStatement -> {
+            final ResultSet resultSet = preparedStatement.executeQuery();
             final List<T> results = new ArrayList<>();
-
-            log.debug("query : {}", sql);
-
             while (resultSet.next()) {
                 results.add(rowMapper.mapping(resultSet));
             }
             return results;
-
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e.getMessage(), e);
-        }
+        }, sql, objects);
     }
 
     public <T> Optional<T> queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... objects) {
-        try (final Connection connection = dataSource.getConnection();
-             final PreparedStatement preparedStatement = prepareStatementWithBindingQuery(connection.prepareStatement(sql), objects);
-             final ResultSet resultSet = preparedStatement.executeQuery()) {
-
-            log.debug("query : {}", sql);
-
+        return preparedStatementExecutor.execute(preparedStatement -> {
+            final ResultSet resultSet = preparedStatement.executeQuery();
             if (resultSet.next()) {
                 return Optional.of(rowMapper.mapping(resultSet));
             }
             return Optional.empty();
-
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new DataAccessException(e.getMessage(), e);
-        }
+        }, sql, objects);
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCallback.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCallback.java
@@ -1,0 +1,10 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementCallback<T> {
+
+    T call(final PreparedStatement preparedStatement) throws SQLException;
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
@@ -1,0 +1,40 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+
+public class PreparedStatementExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(PreparedStatementExecutor.class);
+
+    private final DataSource dataSource;
+
+    public PreparedStatementExecutor(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> T execute(final PreparedStatementCallback<T> preparedStatementCallback, final String sql, final Object... objects) {
+        try (final Connection connection = dataSource.getConnection();
+             final PreparedStatement preparedStatement = prepareStatementWithBindingQuery(connection.prepareStatement(sql), objects)) {
+
+            log.debug("query : {}", sql);
+            return preparedStatementCallback.call(preparedStatement);
+
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new DataAccessException(e.getMessage(), e);
+        }
+    }
+
+    private PreparedStatement prepareStatementWithBindingQuery(final PreparedStatement preparedStatement, final Object... objects) throws SQLException {
+        for (int i = 0; i < objects.length; i++) {
+            preparedStatement.setObject(i + 1, objects[i]);
+        }
+        return preparedStatement;
+    }
+}


### PR DESCRIPTION
안녕하세요 파워! 코코닥입니다

1단계를 통해서 2단계의 요구사항을 대부분 만족했던 것 같아요.

그래서 무엇을 더 리팩터링해볼 수 있을까 고민하다가, `try-catch 구문에 대한 반복을 제거해보면 좋겠다!` 싶어서 해당 부분을 목표로 리팩터링을 진행했습니다.

# 개선 방향

`try-with-resources 구문, SQLException 을 적절한 UncheckedException 으로 치환하는 행위, 로깅 등등의 로직`들이 JdbcTemplate 메서드들에 공통적으로 들어가있는 상황이었습니다.

각 메서드들마다 다른 점은 try-catch 내부의 상세 로직들이었는데요!

그렇다면 공통적으로 들어갔던 로직들을 템플릿화 시킨 후, 기존의 상세 로직을 콜백 객체로 묶어서 파라미터로 넘긴 뒤, 해당 콜백 객체를 실행시키면 코드 중복이 효과적으로 제거되지 않을까? 해서, 해당 방향으로 리팩터링 해보았습니다.

# PreparedStatementCallback

기존 `JdbcTemplate` 내부 메서드들이 가지고 있던 상세 로직들에 대한 콜백 인터페이스입니다.

함수형 인터페이스로 만들어서 람다식으로 상세 로직들을 주입해줄 수 있게 만들어주었습니다.

# PreparedStatementExecutor

템플릿 콜백 패턴을 사용한 클래스입니다.

기존 `JdbcTemplate` 이 가지고 있던 try-catch 구문을 `PreparedStatementExecutor` 내부로 옮겼습니다.

`JdbcTemplate` 에서 상세 로직을 람다식으로 넘기면, `PreparedStatementExecutor` 내부에서는 해당 람다식에 대한 콜백 객체를 실행합니다.

---

마지막으로, `SQLException` 을 적절한 `UncheckedException` 으로 변환시킬 책임은 `JdbcTemplate` 에 있는 것 같아서, 기존에 `RuntimeException` 을 던지던 부분을 `DataAccessException` 으로 변경하였습니다!

리뷰 잘 부탁드립니다 파워!!