### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 이리내(성채연) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -8,15 +8,15 @@ import org.springframework.jdbc.core.RowMapper;
 
 public class UserDao {
 
-    private final JdbcTemplate jdbcTemplate;
-
-    private final RowMapper<User> rowMapper = rs ->
+    private static final RowMapper<User> ROW_MAPPER = rs ->
             new User(
                     rs.getLong("id"),
                     rs.getString("account"),
                     rs.getString("password"),
                     rs.getString("email")
             );
+
+    private final JdbcTemplate jdbcTemplate;
 
     public UserDao(final DataSource dataSource) {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
@@ -38,16 +38,16 @@ public class UserDao {
 
     public List<User> findAll() {
         final String sql = "select id, account, password, email from users";
-        return jdbcTemplate.query(sql, rowMapper);
+        return jdbcTemplate.query(sql, ROW_MAPPER);
     }
 
     public User findById(final Long id) {
         final String sql = "select id, account, password, email from users where id = ?";
-        return jdbcTemplate.queryForObject(sql, rowMapper, id);
+        return jdbcTemplate.queryForObject(sql, ROW_MAPPER, id);
     }
 
     public User findByAccount(final String account) {
         final String sql = "select id, account, password, email from users where account = ?";
-        return jdbcTemplate.queryForObject(sql, rowMapper, account);
+        return jdbcTemplate.queryForObject(sql, ROW_MAPPER, account);
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,62 +1,32 @@
 package com.techcourse.dao;
 
 import com.techcourse.domain.UserHistory;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 public class UserHistoryDao {
 
-    private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
-
-    private final DataSource dataSource;
+    private final JdbcTemplate jdbcTemplate;
 
     public UserHistoryDao(final DataSource dataSource) {
-        this.dataSource = dataSource;
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
-        this.dataSource = null;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
-
-            log.debug("query : {}", sql);
-
-            pstmt.setLong(1, userHistory.getUserId());
-            pstmt.setString(2, userHistory.getAccount());
-            pstmt.setString(3, userHistory.getPassword());
-            pstmt.setString(4, userHistory.getEmail());
-            pstmt.setObject(5, userHistory.getCreatedAt());
-            pstmt.setString(6, userHistory.getCreateBy());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+        jdbcTemplate.update(
+                sql,
+                userHistory.getUserId(),
+                userHistory.getAccount(),
+                userHistory.getPassword(),
+                userHistory.getEmail(),
+                userHistory.getCreatedAt(),
+                userHistory.getCreateBy()
+        );
     }
 }

--- a/app/src/test/java/com/techcourse/dao/UserHistoryDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserHistoryDaoTest.java
@@ -1,0 +1,25 @@
+package com.techcourse.dao;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.techcourse.config.DataSourceConfig;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import org.junit.jupiter.api.Test;
+
+class UserHistoryDaoTest {
+
+    private UserHistoryDao userHistoryDao;
+
+    @Test
+    void log() {
+        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+
+        userHistoryDao = new UserHistoryDao(DataSourceConfig.getInstance());
+        final User user = new User(1L, "irene", "password", "irene@irene.com");
+        final UserHistory userHistory = new UserHistory(user, "irene");
+
+        assertThatCode(() -> userHistoryDao.log(userHistory)).doesNotThrowAnyException();
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ExecutionCallback.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ExecutionCallback.java
@@ -1,0 +1,10 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface ExecutionCallback<T> {
+
+    T execute(final PreparedStatement preparedStatement) throws SQLException;
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCallback.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementCallback.java
@@ -1,0 +1,11 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementCallback {
+
+    PreparedStatement prepareStatement(final Connection connection) throws SQLException;
+}


### PR DESCRIPTION
오랜만이에요 채채
연휴는 잘 보내셨는지요!!

이번 단계에서는 업데이트와 조회 메서드에 중복되는 `try-with-resources` 문을 어떻게 공통 메서드로 분리할 수 있을지에대해 집중해보았어요

update, query, queryForObject 메서드 모두 아래 메서드의 `executionCallback.execute(pstmt)`를 통해 쿼리를 실행하게 되는데요,
```
private <T> T execute(final PreparedStatementCallback preparedStatementCallback,
                         final ExecutionCallback<T> executionCallback) {
        try (final Connection connection = dataSource.getConnection();
             final PreparedStatement pstmt = preparedStatementCallback.prepareStatement(connection)) {
            return executionCallback.execute(pstmt);
        } catch (SQLException e) {
            throw new DataAccessException(e);
        }
    }
```

`update`의 경우에는 `pstmt.executeUpdate()`의 반환값인 `int`를 반환하도록 하고
`query, queryForObject`의 경우에는 `pstmt.executeQuery()`의 결과인 `ResultSet`을 `List<T>로 바꾸는 작업을 추가해서` 반환값이 `List<T>`로 반환되도록 해봤어요(이 부분은 `executeQuery 메서드`도 같이 봐주세욥)

그리고 query 메서드의 경우에는 `List<T>`를 그대로 반환하고,
queryForObject의 경우에는 `원소를 하나만` 반환하도록 하였습니다

리뷰 잘 부탁드려용~😆
