### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 필립(양재필) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -50,14 +50,12 @@ public class UserDao {
     public User findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
 
-        return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, id)
-                .orElseThrow(() -> new RuntimeException("해당되는 id의 사용자를 찾을 수 없습니다."));
+        return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, id);
     }
 
     public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
 
-        return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, account)
-                .orElseThrow(() -> new RuntimeException("해당되는 account의 사용자를 찾을 수 없습니다."));
+        return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, account);
     }
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -5,20 +5,26 @@ import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UserDaoTest {
 
+    private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
+    private Long defaultId;
 
     @BeforeEach
     void setup() {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
 
         userDao = new UserDao(DataSourceConfig.getInstance());
+        jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        jdbcTemplate.update("delete from users");
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
+        defaultId = jdbcTemplate.queryForObject("select id from users where account = ?", resultSet -> resultSet.getLong("id"), "gugu");
     }
 
     @Test
@@ -30,7 +36,7 @@ class UserDaoTest {
 
     @Test
     void findById() {
-        final var user = userDao.findById(1L);
+        final var user = userDao.findById(defaultId);
 
         assertThat(user.getAccount()).isEqualTo("gugu");
     }
@@ -49,7 +55,8 @@ class UserDaoTest {
         final var user = new User(account, "password", "hkkang@woowahan.com");
         userDao.insert(user);
 
-        final var actual = userDao.findById(2L);
+        Long insertedId = jdbcTemplate.queryForObject("select id from users where account = ?", resultSet -> resultSet.getLong("id"), account);
+        final var actual = userDao.findById(insertedId);
 
         assertThat(actual.getAccount()).isEqualTo(account);
     }
@@ -57,12 +64,12 @@ class UserDaoTest {
     @Test
     void update() {
         final var newPassword = "password99";
-        final var user = userDao.findById(1L);
+        final var user = userDao.findById(defaultId);
         user.changePassword(newPassword);
 
         userDao.update(user);
 
-        final var actual = userDao.findById(1L);
+        final var actual = userDao.findById(defaultId);
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }

--- a/app/src/test/java/com/techcourse/dao/UserHistoryDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserHistoryDaoTest.java
@@ -8,13 +8,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class UserHistoryDaoTest {
 
@@ -37,7 +30,7 @@ class UserHistoryDaoTest {
         userHistoryDao.log(userHistory);
 
         var selectSql = "select id, user_id, account, password, email, created_at, created_by from user_history where created_by = ?";
-        Optional<UserHistory> result = jdbcTemplate.queryForObject(selectSql,
+        UserHistory result = jdbcTemplate.queryForObject(selectSql,
                 resultSet -> new UserHistory(
                         resultSet.getLong("id"),
                         resultSet.getLong("user_id"),
@@ -49,9 +42,8 @@ class UserHistoryDaoTest {
                 "sun-shot");
 
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(result).isPresent();
-            softly.assertThat(result.get().getAccount()).isEqualTo("philip");
-            softly.assertThat(result.get().getCreateBy()).isEqualTo("sun-shot");
+            softly.assertThat(result.getAccount()).isEqualTo("philip");
+            softly.assertThat(result.getCreateBy()).isEqualTo("sun-shot");
         });
     }
 

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -19,4 +19,6 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.2"
     testImplementation "org.mockito:mockito-core:5.4.0"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.7.2"
+
+    testImplementation "com.h2database:h2:2.2.220"
 }

--- a/jdbc/src/main/java/org/springframework/dao/JdbcException.java
+++ b/jdbc/src/main/java/org/springframework/dao/JdbcException.java
@@ -1,0 +1,23 @@
+package org.springframework.dao;
+
+public class JdbcException extends RuntimeException {
+
+    public JdbcException() {
+    }
+
+    public JdbcException(String message) {
+        super(message);
+    }
+
+    public JdbcException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public JdbcException(Throwable cause) {
+        super(cause);
+    }
+
+    public JdbcException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -10,7 +10,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class JdbcTemplate {
 
@@ -53,7 +52,7 @@ public class JdbcTemplate {
         }
     }
 
-    public <T> Optional<T> queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
+    public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
         try (
                 final Connection conn = dataSource.getConnection();
                 final PreparedStatement pstmt = getPrepareStatement(conn, sql, args);
@@ -61,14 +60,15 @@ public class JdbcTemplate {
         ) {
             log.debug("run sql {}", sql);
             if (resultSet.next()) {
-                final T data = rowMapper.map(resultSet);
+                final T result = rowMapper.map(resultSet);
                 if (resultSet.next()) {
                     log.error("selected data count is larger than 1");
                     throw new RuntimeException("selected data count is larger than 1");
                 }
-                return Optional.of(data);
+                return result;
             }
-            return Optional.empty();
+            log.error("no data found");
+            throw new RuntimeException("no data found");
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new RuntimeException(e);

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -62,18 +62,27 @@ public class JdbcTemplate {
             log.debug("run sql {}", sql);
             if (resultSet.next()) {
                 final T result = rowMapper.map(resultSet);
-                if (resultSet.next()) {
-                    log.error("selected data count is larger than 1");
-                    throw new JdbcException("selected data count is larger than 1");
-                }
+                validateIsOnlyResult(resultSet);
                 return result;
             }
-            log.error("no data found");
-            throw new JdbcException("no data found");
+            logAndThrowNoDataFoundException();
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new JdbcException(e);
         }
+        return null;
+    }
+
+    private void validateIsOnlyResult(ResultSet resultSet) throws SQLException {
+        if (resultSet.next()) {
+            log.error("selected data count is larger than 1");
+            throw new JdbcException("selected data count is larger than 1");
+        }
+    }
+
+    private static void logAndThrowNoDataFoundException() {
+        log.error("no data found");
+        throw new JdbcException("no data found");
     }
 
     private PreparedStatement getPrepareStatement(final Connection connection, final String sql, final Object[] args) throws SQLException {

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -61,7 +61,12 @@ public class JdbcTemplate {
         ) {
             log.debug("run sql {}", sql);
             if (resultSet.next()) {
-                return Optional.of(rowMapper.map(resultSet));
+                final T data = rowMapper.map(resultSet);
+                if (resultSet.next()) {
+                    log.error("selected data count is larger than 1");
+                    throw new RuntimeException("selected data count is larger than 1");
+                }
+                return Optional.of(data);
             }
             return Optional.empty();
         } catch (SQLException e) {

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -2,6 +2,7 @@ package org.springframework.jdbc.core;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.JdbcException;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -30,7 +31,7 @@ public class JdbcTemplate {
             return pstmt.executeUpdate();
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new JdbcException(e);
         }
     }
 
@@ -48,7 +49,7 @@ public class JdbcTemplate {
             return results;
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new JdbcException(e);
         }
     }
 
@@ -63,15 +64,15 @@ public class JdbcTemplate {
                 final T result = rowMapper.map(resultSet);
                 if (resultSet.next()) {
                     log.error("selected data count is larger than 1");
-                    throw new RuntimeException("selected data count is larger than 1");
+                    throw new JdbcException("selected data count is larger than 1");
                 }
                 return result;
             }
             log.error("no data found");
-            throw new RuntimeException("no data found");
+            throw new JdbcException("no data found");
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new JdbcException(e);
         }
     }
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -25,12 +25,8 @@ public class JdbcTemplate {
     public int update(final String sql, final Object... args) {
         try (
                 final Connection conn = dataSource.getConnection();
-                final PreparedStatement pstmt = conn.prepareStatement(sql)
+                final PreparedStatement pstmt = getPrepareStatement(conn, sql, args)
         ) {
-            for (int parameterIndex = 0; parameterIndex < args.length; parameterIndex++) {
-                pstmt.setString(parameterIndex + 1, String.valueOf(args[parameterIndex]));
-            }
-
             log.debug("run sql {}", sql);
             return pstmt.executeUpdate();
         } catch (SQLException e) {
@@ -42,12 +38,8 @@ public class JdbcTemplate {
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... args) {
         try (
                 final Connection conn = dataSource.getConnection();
-                final PreparedStatement pstmt = conn.prepareStatement(sql)
+                final PreparedStatement pstmt = getPrepareStatement(conn, sql, args)
         ) {
-            for (int parameterIndex = 0; parameterIndex < args.length; parameterIndex++) {
-                pstmt.setString(parameterIndex + 1, String.valueOf(args[parameterIndex]));
-            }
-
             final ResultSet resultSet = pstmt.executeQuery();
             final List<T> results = new ArrayList<>();
             while (resultSet.next()) {
@@ -65,12 +57,8 @@ public class JdbcTemplate {
     public <T> Optional<T> queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
         try (
                 final Connection conn = dataSource.getConnection();
-                final PreparedStatement pstmt = conn.prepareStatement(sql)
+                final PreparedStatement pstmt = getPrepareStatement(conn, sql, args)
         ) {
-            for (int parameterIndex = 0; parameterIndex < args.length; parameterIndex++) {
-                pstmt.setString(parameterIndex + 1, String.valueOf(args[parameterIndex]));
-            }
-
             final ResultSet resultSet = pstmt.executeQuery();
 
             log.debug("run sql {}", sql);
@@ -81,6 +69,18 @@ public class JdbcTemplate {
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new RuntimeException(e);
+        }
+    }
+
+    private PreparedStatement getPrepareStatement(final Connection connection, final String sql, final Object[] args) throws SQLException {
+        final PreparedStatement pstm = connection.prepareStatement(sql);
+        setSqlParameters(pstm, args);
+        return pstm;
+    }
+
+    private void setSqlParameters(final PreparedStatement pstmt, final Object[] args) throws SQLException {
+        for (int parameterIndex = 0; parameterIndex < args.length; parameterIndex++) {
+            pstmt.setString(parameterIndex + 1, String.valueOf(args[parameterIndex]));
         }
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -38,14 +38,13 @@ public class JdbcTemplate {
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... args) {
         try (
                 final Connection conn = dataSource.getConnection();
-                final PreparedStatement pstmt = getPrepareStatement(conn, sql, args)
+                final PreparedStatement pstmt = getPrepareStatement(conn, sql, args);
+                final ResultSet resultSet = pstmt.executeQuery()
         ) {
-            final ResultSet resultSet = pstmt.executeQuery();
             final List<T> results = new ArrayList<>();
             while (resultSet.next()) {
                 results.add(rowMapper.map(resultSet));
             }
-
             log.debug("run sql {}", sql);
             return results;
         } catch (SQLException e) {
@@ -57,10 +56,9 @@ public class JdbcTemplate {
     public <T> Optional<T> queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
         try (
                 final Connection conn = dataSource.getConnection();
-                final PreparedStatement pstmt = getPrepareStatement(conn, sql, args)
+                final PreparedStatement pstmt = getPrepareStatement(conn, sql, args);
+                final ResultSet resultSet = pstmt.executeQuery()
         ) {
-            final ResultSet resultSet = pstmt.executeQuery();
-
             log.debug("run sql {}", sql);
             if (resultSet.next()) {
                 return Optional.of(rowMapper.map(resultSet));

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -1,5 +1,216 @@
 package nextstep.jdbc;
 
+import nextstep.jdbc.support.DataSourceConfig;
+import nextstep.jdbc.support.DatabasePopulatorUtils;
+import nextstep.jdbc.support.TestData;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 class JdbcTemplateTest {
 
+    private static final RowMapper<TestData> TEST_DATA_ROW_MAPPER = resultSet -> {
+        long id = resultSet.getLong("id");
+        String content = resultSet.getString("content");
+        int num = resultSet.getInt("num");
+        return new TestData(id, content, num);
+    };
+
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setup() {
+        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+        jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+
+        final TestData testData = new TestData("firstData", 1);
+        jdbcTemplate.update("insert into test_data (content, num) values (?, ?)", testData.getContent(), testData.getNum());
+    }
+
+    @Nested
+    class UpdateTest {
+
+        @Test
+        @DisplayName("insert 쿼리 테스트")
+        void successInsertQuery() {
+            // given
+            final TestData testData = new TestData("content", 1);
+            final String sql = "insert into test_data (content, num) values (?, ?)";
+
+            // when
+            final int updatedRowNum = jdbcTemplate.update(sql, testData.getContent(), testData.getNum());
+
+            // then
+            assertThat(updatedRowNum).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("update 쿼리 테스트")
+        void successUpdateQuery() {
+            // given
+            final String sql = "update test_data set content = ?, num = ? where id = ?";
+
+            // when
+            int updatedRowNum = jdbcTemplate.update(sql, "new content", 2, 1);
+
+            // then
+            assertThat(updatedRowNum).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("파라미터 수가 적은 경우 않으면 예외를 발생시킨다")
+        void throwExceptionIfParameterInputIsLessThenQuestionMark() {
+            // given
+            final TestData testData = new TestData("content", 1);
+            final String sql = "insert into test_data (content, num) values (?, ?)";
+
+            // when
+            // then
+            Assertions.assertThatThrownBy(() -> jdbcTemplate.update(sql, testData.getContent()))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Parameter \"#2\" is not set; SQL statement:");
+        }
+
+        @Test
+        @DisplayName("파라미터 수가 많은 경우 않으면 예외를 발생시킨다")
+        void throwExceptionIfParameterInputIsLargerThenQuestionMark() {
+            // given
+            final TestData testData = new TestData("content", 1);
+            final String sql = "insert into test_data (content, num) values (?, ?)";
+
+            // when
+            // then
+            Assertions.assertThatThrownBy(() -> jdbcTemplate.update(sql, testData.getContent(), testData.getNum(), "additional-input"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Invalid value \"3\" for parameter \"parameterIndex\"");
+        }
+    }
+
+    @Nested
+    class QueryTest {
+
+        @Test
+        @DisplayName("성공 테스트")
+        void success() {
+            // given
+            final String sql = "select id, content, num from test_data where id = ?";
+
+            // when
+            List<TestData> actual = jdbcTemplate.query(sql, TEST_DATA_ROW_MAPPER, 1L);
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(actual).hasSize(1);
+                softly.assertThat(actual.get(0).getContent()).isEqualTo("firstData");
+            });
+        }
+
+        @Test
+        @DisplayName("파라미터 수가 적은 경우 않으면 예외를 발생시킨다")
+        void throwExceptionIfParameterInputIsLessThenQuestionMark() {
+            // given
+            final String sql = "select id, content, num from test_data where id = ?";
+
+            // when
+            // then
+            Assertions.assertThatThrownBy(() -> jdbcTemplate.query(sql, TEST_DATA_ROW_MAPPER))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Parameter \"#1\" is not set; SQL statement:");
+        }
+
+        @Test
+        @DisplayName("파라미터 수가 많은 경우 않으면 예외를 발생시킨다")
+        void throwExceptionIfParameterInputIsLargerThenQuestionMark() {
+            // given
+            final String sql = "select id, content, num from test_data where id = ?";
+
+            // when
+            // then
+            Assertions.assertThatThrownBy(() -> jdbcTemplate.query(sql, TEST_DATA_ROW_MAPPER, 1, "additional-data"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Invalid value \"2\" for parameter \"parameterIndex\"");
+        }
+    }
+
+    @Nested
+    class QueryForObjectTest {
+
+        @Test
+        @DisplayName("성공 테스트")
+        void success() {
+            // given
+            final String sql = "select id, content, num from test_data where id = ?";
+
+            // when
+            Optional<TestData> actual = jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, 1L);
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(actual).isPresent();
+                softly.assertThat(actual.get().getContent()).isEqualTo("firstData");
+            });
+        }
+
+        @Test
+        @DisplayName("조회한 정보가 없는경우")
+        void whenDataIsNotExist() {
+            // given
+            final String sql = "select id, content, num from test_data where id = ?";
+
+            // when
+            Optional<TestData> actual = jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, -1L);
+
+            // then
+            assertThat(actual).isEmpty();
+        }
+
+        @Test
+        @DisplayName("해당되는 정보가 많은경우")
+        void whenMatchedDataIsMoreThan2() {
+            // given
+            jdbcTemplate.update("insert into test_data (content, num) values (?, ?)", "new data", 1);
+            final String sql = "select id, content, num from test_data where num = ?";
+
+            // when
+            Optional<TestData> actual = jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, 1L);
+
+            // then
+        }
+
+        @Test
+        @DisplayName("파라미터 수가 적은 경우 않으면 예외를 발생시킨다")
+        void throwExceptionIfParameterInputIsLessThenQuestionMark() {
+            // given
+            final String sql = "select id, content, num from test_data where id = ?";
+
+            // when
+            // then
+            Assertions.assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Parameter \"#1\" is not set; SQL statement:");
+        }
+
+        @Test
+        @DisplayName("파라미터 수가 많은 경우 않으면 예외를 발생시킨다")
+        void throwExceptionIfParameterInputIsLargerThenQuestionMark() {
+            // given
+            final String sql = "select id, content, num from test_data where id = ?";
+
+            // when
+            // then
+            Assertions.assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, 1, "additional-data"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Invalid value \"2\" for parameter \"parameterIndex\"");
+        }
+    }
 }

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.JdbcException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
@@ -76,7 +77,7 @@ class JdbcTemplateTest {
             // when
             // then
             Assertions.assertThatThrownBy(() -> jdbcTemplate.update(sql, testData.getContent()))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(JdbcException.class)
                     .hasMessageContaining("Parameter \"#2\" is not set; SQL statement:");
         }
 
@@ -90,7 +91,7 @@ class JdbcTemplateTest {
             // when
             // then
             Assertions.assertThatThrownBy(() -> jdbcTemplate.update(sql, testData.getContent(), testData.getNum(), "additional-input"))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(JdbcException.class)
                     .hasMessageContaining("Invalid value \"3\" for parameter \"parameterIndex\"");
         }
     }
@@ -123,7 +124,7 @@ class JdbcTemplateTest {
             // when
             // then
             Assertions.assertThatThrownBy(() -> jdbcTemplate.query(sql, TEST_DATA_ROW_MAPPER))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(JdbcException.class)
                     .hasMessageContaining("Parameter \"#1\" is not set; SQL statement:");
         }
 
@@ -136,7 +137,7 @@ class JdbcTemplateTest {
             // when
             // then
             Assertions.assertThatThrownBy(() -> jdbcTemplate.query(sql, TEST_DATA_ROW_MAPPER, 1, "additional-data"))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(JdbcException.class)
                     .hasMessageContaining("Invalid value \"2\" for parameter \"parameterIndex\"");
         }
     }
@@ -168,7 +169,7 @@ class JdbcTemplateTest {
 
             // when
             Assertions.assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, -1L))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(JdbcException.class)
                     .hasMessage("no data found");
         }
 
@@ -182,7 +183,7 @@ class JdbcTemplateTest {
             // when
             // then
             Assertions.assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, 1L))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(JdbcException.class)
                     .hasMessage("selected data count is larger than 1");
         }
 
@@ -195,7 +196,7 @@ class JdbcTemplateTest {
             // when
             // then
             Assertions.assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(JdbcException.class)
                     .hasMessageContaining("Parameter \"#1\" is not set; SQL statement:");
         }
 
@@ -208,7 +209,7 @@ class JdbcTemplateTest {
             // when
             // then
             Assertions.assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, 1, "additional-data"))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(JdbcException.class)
                     .hasMessageContaining("Invalid value \"2\" for parameter \"parameterIndex\"");
         }
     }

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -182,9 +182,10 @@ class JdbcTemplateTest {
             final String sql = "select id, content, num from test_data where num = ?";
 
             // when
-            Optional<TestData> actual = jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, 1L);
-
             // then
+            Assertions.assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, 1L))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("selected data count is larger than 1");
         }
 
         @Test

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -13,7 +13,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -152,12 +151,12 @@ class JdbcTemplateTest {
             final String sql = "select id, content, num from test_data where id = ?";
 
             // when
-            Optional<TestData> actual = jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, 1L);
+            TestData actual = jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, 1L);
 
             // then
             SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(actual).isPresent();
-                softly.assertThat(actual.get().getContent()).isEqualTo("firstData");
+                softly.assertThat(actual.getContent()).isEqualTo("firstData");
+                softly.assertThat(actual.getNum()).isEqualTo(1);
             });
         }
 
@@ -168,10 +167,9 @@ class JdbcTemplateTest {
             final String sql = "select id, content, num from test_data where id = ?";
 
             // when
-            Optional<TestData> actual = jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, -1L);
-
-            // then
-            assertThat(actual).isEmpty();
+            Assertions.assertThatThrownBy(() -> jdbcTemplate.queryForObject(sql, TEST_DATA_ROW_MAPPER, -1L))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("no data found");
         }
 
         @Test

--- a/jdbc/src/test/java/nextstep/jdbc/support/DataSourceConfig.java
+++ b/jdbc/src/test/java/nextstep/jdbc/support/DataSourceConfig.java
@@ -1,0 +1,27 @@
+package nextstep.jdbc.support;
+
+import org.h2.jdbcx.JdbcDataSource;
+
+import java.util.Objects;
+
+public class DataSourceConfig {
+
+    private static javax.sql.DataSource INSTANCE;
+
+    public static javax.sql.DataSource getInstance() {
+        if (Objects.isNull(INSTANCE)) {
+            INSTANCE = createJdbcDataSource();
+        }
+        return INSTANCE;
+    }
+
+    private static JdbcDataSource createJdbcDataSource() {
+        final var jdbcDataSource = new JdbcDataSource();
+        jdbcDataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;");
+        jdbcDataSource.setUser("");
+        jdbcDataSource.setPassword("");
+        return jdbcDataSource;
+    }
+
+    private DataSourceConfig() {}
+}

--- a/jdbc/src/test/java/nextstep/jdbc/support/DatabasePopulatorUtils.java
+++ b/jdbc/src/test/java/nextstep/jdbc/support/DatabasePopulatorUtils.java
@@ -1,0 +1,46 @@
+package nextstep.jdbc.support;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class DatabasePopulatorUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(DatabasePopulatorUtils.class);
+
+    public static void execute(final DataSource dataSource) {
+        Connection connection = null;
+        Statement statement = null;
+        try {
+            final var url = DatabasePopulatorUtils.class.getClassLoader().getResource("schema.sql");
+            final var file = new File(url.getFile());
+            final var sql = Files.readString(file.toPath());
+            connection = dataSource.getConnection();
+            statement = connection.createStatement();
+            statement.execute(sql);
+        } catch (NullPointerException | IOException | SQLException e) {
+            log.error(e.getMessage(), e);
+        } finally {
+            try {
+                if (statement != null) {
+                    statement.close();
+                }
+            } catch (SQLException ignored) {}
+
+            try {
+                if (connection != null) {
+                    connection.close();
+                }
+            } catch (SQLException ignored) {}
+        }
+    }
+
+    private DatabasePopulatorUtils() {}
+}

--- a/jdbc/src/test/java/nextstep/jdbc/support/TestData.java
+++ b/jdbc/src/test/java/nextstep/jdbc/support/TestData.java
@@ -1,0 +1,42 @@
+package nextstep.jdbc.support;
+
+public class TestData {
+
+    private Long id;
+    private String content;
+    private int num;
+
+    public TestData() {
+    }
+
+    public TestData(final String content, final int num) {
+        this.content = content;
+        this.num = num;
+    }
+
+    public TestData(final Long id, final String content, final int num) {
+        this.id = id;
+        this.content = content;
+        this.num = num;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public int getNum() {
+        return num;
+    }
+
+    public void setContent(final String content) {
+        this.content = content;
+    }
+
+    public void setNum(int num) {
+        this.num = num;
+    }
+}

--- a/jdbc/src/test/resources/schema.sql
+++ b/jdbc/src/test/resources/schema.sql
@@ -1,0 +1,6 @@
+create table if not exists test_data (
+    id bigint auto_increment,
+    content varchar(100) not null,
+    num int,
+    primary key(id)
+ );


### PR DESCRIPTION
안녕하세요 썬샷!!

2단계 미션제출합니다!

우선 썬샷이 남겨주신 코멘트들에 대한 내용입니다.

[? 갯수와 args 처리](https://github.com/woowacourse/jwp-dashboard-jdbc/pull/326#discussion_r1341992119)
> 추가적으로 쿼리문의 `?` 갯수와 args.length가 다른 경우는 어떻게 처리해주는 건가요? 전부 SQLException에 포함이 되나요?

해당 부분은 신경쓰지못하였었는데, 확인해보니 `SQLException`에 포함이 되어있더라고요.그래서 이부분은 추가적으로 검증을 한번 더 해야할까 아니면 포함이 되어있으니 추가작업은 없어도 되는것을까 하는 고민을 해보았습니다.
결과적으로 그냥 SQLEcpetion에 포함이 되어있으니 추가적인 검증은 안하기로 하였습니다.
이유는 JDBC라는것이 라이브러리이기때문에 명시적으로 한번 더 검증을 해준다보다도 매 요청마다 String에 대한 검증을 해주는 것에 대한 리소스를 줄이는것이 더 적합하지 않을까 하는 생각에서 안하고 그냥 SQLEception으로 한번만 검증이 되로고 처리하였습니다.

[queryForObject의 결과 row수에 대한 예외처리](https://github.com/woowacourse/jwp-dashboard-jdbc/pull/326#discussion_r1341992024)
> 반환형이나 메서드명으로 봤을 때 queryForObject가 한 개의 요소만 반환하는 것을 기대하는 것 같은데 ResultSet에 여러 요소가 들어있는 경우는 어떻게 처리하는 것이 좋을까요?

이부분도 신경을 못썻었는데,, 해당 메서드는 사용자가 단 1개의 결과를 기대하고 사용하기때문에, 결과가 2개 이상인경우와, 없는경우에 대한 예외처리가 들어가야 한다고 생각합니다. 실제 jdbc template의 문서를 확인해보니 실제로도 데이터가 없거나 여러개인경우 예외처리를 하더라고요...
그래서 저도 마찬가지로 없는경우와 2개이상인경우 예외를 던지도록 하였습니다.
추가로 없는경우도 예외를 던지도록 작업이 되어서 반환형도 `Optional<T>`가 아닌 그냥 `T`객체로 반환하도록 변경하였습니다.

---

2단계에서는 크게 무엇을 더 해야하는지 감이 안와서 일단 래펙터링이 가능한대로 해보기만 하였습니다...

추가적으로 JdbcTemplate의 기능과 예외처리등에 대한 테스트를 위해서 JdbcTemplate테스트를 추가하였고, 기존 UserDaoTest에서는 중복된 결과조회에 대한 검증이 없을때 통과하던거라서... BeforeEach에서 데이터 추가전에 그냥 있는것들 delete쿼리 날리도록만 처리해두었습니다.

혹시 제가 놓치고있는 부분이나 리팩터링이 필요한 부분 있으면 지적 부탁드립니다!!

ps. 이번 자리배정은 뒤에서 2등을 하였지만... 원래 팀원들이 우리가 그동안 너무 고립되어있었다고 자리선택할 기회가 생기면 이번엔 굿샷가는거 어떠냔 이야기가 있었어서 결과적으론 만족스러운 자리를 잘 먹었습니다..ㅋㅋㅋㅋ
썬샷은 이번 플젝의 마지막 자리 만족스러우신 자리 잘 배정받으셨나요??