### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 도이(유도영) 미션 제출합니다. 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation "org.apache.commons:commons-lang3:3.13.0"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
     implementation "com.h2database:h2:2.2.220"
+    implementation 'com.zaxxer:HikariCP:5.0.1'
 
     testImplementation "org.assertj:assertj-core:3.24.2"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.2"

--- a/app/src/main/java/com/techcourse/config/DataSourceConfig.java
+++ b/app/src/main/java/com/techcourse/config/DataSourceConfig.java
@@ -1,7 +1,8 @@
 package com.techcourse.config;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import java.util.Objects;
-import org.h2.jdbcx.JdbcDataSource;
 
 public class DataSourceConfig {
 
@@ -9,17 +10,18 @@ public class DataSourceConfig {
 
     public static javax.sql.DataSource getInstance() {
         if (Objects.isNull(INSTANCE)) {
-            INSTANCE = createJdbcDataSource();
+            INSTANCE = createHikariDataSource();
         }
         return INSTANCE;
     }
 
-    private static JdbcDataSource createJdbcDataSource() {
-        final var jdbcDataSource = new JdbcDataSource();
-        jdbcDataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;");
-        jdbcDataSource.setUser("");
-        jdbcDataSource.setPassword("");
-        return jdbcDataSource;
+    private static HikariDataSource createHikariDataSource() {
+        final var hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;");
+        hikariConfig.setUsername("");
+        hikariConfig.setPassword("");
+
+        return new HikariDataSource(hikariConfig);
     }
 
     private DataSourceConfig() {}

--- a/app/src/main/java/com/techcourse/support/jdbc/init/DataSourceConnectionManager.java
+++ b/app/src/main/java/com/techcourse/support/jdbc/init/DataSourceConnectionManager.java
@@ -9,9 +9,15 @@ import org.springframework.jdbc.core.ConnectionManager;
 
 public class DataSourceConnectionManager implements ConnectionManager {
 
+    private final DataSource dataSource;
+
+    public DataSourceConnectionManager() {
+        this.dataSource = DataSourceConfig.getInstance();
+    }
+
+    @Override
     public Connection getConnection() throws CannotGetJdbcConnectionException {
         try {
-            DataSource dataSource = DataSourceConfig.getInstance();
             return dataSource.getConnection();
         } catch (final SQLException exception) {
             throw new CannotGetJdbcConnectionException("Datasource connection error:" + exception.getMessage());

--- a/app/src/main/java/com/techcourse/support/jdbc/init/PooledDataSourceConnectionManager.java
+++ b/app/src/main/java/com/techcourse/support/jdbc/init/PooledDataSourceConnectionManager.java
@@ -4,8 +4,6 @@ import com.techcourse.config.DataSourceConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
 import org.springframework.jdbc.core.ConnectionManager;
 

--- a/app/src/main/java/com/techcourse/support/jdbc/init/PooledDataSourceConnectionManager.java
+++ b/app/src/main/java/com/techcourse/support/jdbc/init/PooledDataSourceConnectionManager.java
@@ -1,24 +1,27 @@
 package com.techcourse.support.jdbc.init;
 
 import com.techcourse.config.DataSourceConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
 import org.springframework.jdbc.core.ConnectionManager;
 
-public class DataSourceConnectionManager implements ConnectionManager {
+public class PooledDataSourceConnectionManager implements ConnectionManager {
 
-    private final DataSource dataSource;
+    private final HikariDataSource dataSource;
 
-    public DataSourceConnectionManager() {
-        this.dataSource = DataSourceConfig.getInstance();
+    public PooledDataSourceConnectionManager() {
+        this.dataSource = (HikariDataSource) DataSourceConfig.getInstance();
     }
 
     @Override
     public Connection getConnection() throws CannotGetJdbcConnectionException {
         try {
-            return dataSource.getConnection();
+            final var connection = dataSource.getConnection();
+            return connection;
         } catch (final SQLException exception) {
             throw new CannotGetJdbcConnectionException("Datasource connection error:" + exception.getMessage());
         }

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -12,4 +12,8 @@
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
+
+    <logger name="com.zaxxer.hikari" level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </logger>
 </configuration>

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
-import com.techcourse.support.jdbc.init.DataSourceConnectionManager;
+import com.techcourse.support.jdbc.init.PooledDataSourceConnectionManager;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,7 +18,7 @@ class UserDaoTest {
     void setup() {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
 
-        userDao = new UserDao(new JdbcTemplate(new DataSourceConnectionManager()));
+        userDao = new UserDao(new JdbcTemplate(new PooledDataSourceConnectionManager()));
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -7,7 +7,7 @@ import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.support.jdbc.init.DataSourceConnectionManager;
+import com.techcourse.support.jdbc.init.PooledDataSourceConnectionManager;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -23,7 +23,7 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        this.jdbcTemplate = new JdbcTemplate(new DataSourceConnectionManager());
+        this.jdbcTemplate = new JdbcTemplate(new PooledDataSourceConnectionManager());
         this.userDao = new UserDao(jdbcTemplate);
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation "org.reflections:reflections:0.10.2"
     implementation "org.apache.commons:commons-lang3:3.13.0"
     implementation "ch.qos.logback:logback-classic:1.2.12"
+    implementation "com.h2database:h2:2.2.220"
 
     testImplementation "org.assertj:assertj-core:3.24.2"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.2"

--- a/jdbc/src/main/java/org/springframework/jdbc/SqlQueryException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/SqlQueryException.java
@@ -1,4 +1,4 @@
-package org.springframework;
+package org.springframework.jdbc;
 
 public class SqlQueryException extends RuntimeException {
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionCallback.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionCallback.java
@@ -1,0 +1,11 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface ConnectionCallback <T> {
+
+    T doInConnection(Connection connection, PreparedStatement preparedStatement) throws SQLException;
+
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionCallback.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionCallback.java
@@ -4,7 +4,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-public interface ConnectionCallback <T> {
+@FunctionalInterface
+public interface ConnectionCallback<T> {
 
     T doInConnection(Connection connection, PreparedStatement preparedStatement) throws SQLException;
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.SqlQueryException;
+import org.springframework.jdbc.SqlQueryException;
 
 public class JdbcTemplate {
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -16,18 +16,18 @@ public class JdbcTemplate {
 
     private final ConnectionManager connectionManager;
 
-    public JdbcTemplate(ConnectionManager connectionManager) {
+    public JdbcTemplate(final ConnectionManager connectionManager) {
         this.connectionManager = connectionManager;
     }
 
-    public int executeUpdate(String query, Object... parameters) {
+    public int executeUpdate(final String query, final Object... parameters) {
         return execute(query, (connection, preparedStatement) -> preparedStatement.executeUpdate(), parameters);
     }
 
     public <T> T executeQueryForObject(
-            String query,
-            RowMapper<T> rowMapper,
-            Object... parameters
+            final String query,
+            final RowMapper<T> rowMapper,
+            final Object... parameters
     ) {
         final ResultSetExtractor<T> resultSetExtractor = resultSet -> {
             if (resultSet.next()) {
@@ -40,9 +40,9 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> executeQueryForList(
-            String query,
-            RowMapper<T> rowMapper,
-            Object... parameters
+            final String query,
+            final RowMapper<T> rowMapper,
+            final Object... parameters
     ) {
         final ResultSetExtractor<List<T>> resultSetExtractor = resultSet -> {
             final List<T> results = new ArrayList<>();
@@ -56,9 +56,9 @@ public class JdbcTemplate {
     }
 
     public <T> T executeQuery(
-            String query,
-            ResultSetExtractor<T> resultSetExtractor,
-            Object... parameters
+            final String query,
+            final ResultSetExtractor<T> resultSetExtractor,
+            final Object... parameters
     ) {
         return execute(query, (connection, preparedStatement) -> {
             try (final ResultSet resultSet = preparedStatement.executeQuery()) {
@@ -67,7 +67,11 @@ public class JdbcTemplate {
         }, parameters);
     }
 
-    private <T> T execute(String query, ConnectionCallback<T> callback, Object... parameters) {
+    private <T> T execute(
+            final String query,
+            final ConnectionCallback<T> callback,
+            final Object... parameters
+    ) {
         try (final Connection connection = connectionManager.getConnection();
              final PreparedStatement preparedStatement = connection.prepareStatement(query)) {
             log.info("query: {}", query);
@@ -78,7 +82,8 @@ public class JdbcTemplate {
         }
     }
 
-    private void setParameters(PreparedStatement preparedStatement, Object... parameters) throws SQLException {
+    private void setParameters(final PreparedStatement preparedStatement, final Object... parameters)
+            throws SQLException {
         for (int index = 1; index <= parameters.length; index++) {
             preparedStatement.setString(index, String.valueOf(parameters[index - 1]));
         }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ResultSetExtractor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ResultSetExtractor.java
@@ -1,0 +1,11 @@
+package org.springframework.jdbc.core;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+
+public interface ResultSetExtractor<T> {
+
+    T extract(ResultSet resultSet) throws SQLException;
+
+}

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -97,9 +97,6 @@ class JdbcTemplateTest {
             try {
                 final var jdbcDataSource = new JdbcDataSource();
                 jdbcDataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;");
-//                jdbcDataSource.setUser("");
-//                jdbcDataSource.setPassword("");
-
                 return jdbcDataSource.getConnection();
             } catch (SQLException sqlException) {
                 throw new AssertionError();

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -1,5 +1,109 @@
 package nextstep.jdbc;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.CannotGetJdbcConnectionException;
+import org.springframework.jdbc.core.ConnectionManager;
+import org.springframework.jdbc.core.JdbcTemplate;
+
 class JdbcTemplateTest {
 
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        TestConnectionManager connectionManager = new TestConnectionManager();
+        this.jdbcTemplate = new JdbcTemplate(connectionManager);
+        try (Connection conn = connectionManager.getConnection()) {
+            conn.setAutoCommit(true);
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("DROP TABLE IF EXISTS users;");
+                stmt.execute("CREATE TABLE IF NOT EXISTS users (id INT AUTO_INCREMENT PRIMARY KEY, email VARCHAR(100) NOT NULL)");
+                stmt.executeUpdate("INSERT INTO users (email) VALUES ('hkkang@woowahan.com')");
+                conn.setAutoCommit(false);
+            }
+        } catch (SQLException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    @DisplayName("쓰기 작업(생성, 수정, 삭제)을 하는 쿼리를 실행한다.")
+    void executeUpdate() {
+        try {
+            jdbcTemplate.executeUpdate("insert into users (email) values (?)", "doy@gmail.com");
+        } catch (Exception exception) {
+            Assertions.fail(exception);
+        }
+    }
+
+    @Test
+    @DisplayName("단건 레코드를 조회하는 쿼리를 실행한다.")
+    void executeQueryForObject() {
+        try {
+            User user = jdbcTemplate.executeQueryForObject(
+                    "select email from users where id = ?",
+                    resultSet -> new User(resultSet.getString(1)), 1L
+            );
+
+            assertThat(user).usingRecursiveComparison()
+                    .comparingOnlyFields("hkkang@woowahan.com");
+        } catch (Exception exception) {
+            Assertions.fail(exception);
+        }
+    }
+
+    @Test
+    @DisplayName("다건 레코드를 조회하는 쿼리를 실행한다.")
+    void executeQueryForList() {
+        try {
+            jdbcTemplate.executeUpdate("insert into users (email) values (?)", "doy@gmail.com");
+
+            List<User> users = jdbcTemplate.executeQueryForList(
+                    "select email from users",
+                    resultSet -> new User(resultSet.getString(1))
+            );
+
+            assertThat(users).extracting("email")
+                    .containsExactlyInAnyOrder("hkkang@woowahan.com", "doy@gmail.com");
+        } catch (Exception exception) {
+            Assertions.fail(exception);
+        }
+    }
+
+    private static class User {
+
+        private final String email;
+
+        public User(final String email) {
+            this.email = email;
+        }
+
+    }
+
+    private static class TestConnectionManager implements ConnectionManager {
+
+        @Override
+        public Connection getConnection() throws CannotGetJdbcConnectionException {
+            try {
+                final var jdbcDataSource = new JdbcDataSource();
+                jdbcDataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;");
+//                jdbcDataSource.setUser("");
+//                jdbcDataSource.setPassword("");
+
+                return jdbcDataSource.getConnection();
+            } catch (SQLException sqlException) {
+                throw new AssertionError();
+            }
+        }
+    }
 }


### PR DESCRIPTION
안녕하세요 에코!!  
연휴에도 빠르게 리뷰해주셨는데, 프로젝트 우선순위에 밀려서 2단계를 조금 늦게 제출하네요..ㅎㅎ  
지난 리뷰 #316 에 코멘트 답변들도 남겨두었습니다~!

이번 리팩터링에서는 힌트를 보지 않고 기존 JdbcTemplate의 중복 코드를 제거하는 데 집중했습니다.  
- 안정적인 리팩터링을 위해, (UserDaoTest로도 확인 가능하지만) JdbcTemplateTest를 작성하고 진행했습니다.  
- 에코가 제안해주신 덕분에 커넥션풀을 적용해보는 경험을 했어요! HikariCP 의존성을 추가한 이유는 아래와 같습니다.
   - 의존성 추가 없이 하는 법을 고민했는데요. JdbcConnectionPool을 사용하면 가능하지만,  H2에서만 지원된다는 점이 아쉬웠어요. 또, 실제로 스프링부트에서 사용하는 커넥션 풀을 써보고 싶었어요. 추가로, 로그를 통해 진짜 커넥션을 기본값(10개)만큼 미리 만드는지 확인해보았습니다.
- 트랜잭션 적용은, 지금은 조금 감이 안오기도 하고 3단계 요구사항과도 겹쳐서 3단계와 함께 진행하려고 합니다.

이번에도 좋은 리뷰 부탁드려요 🙇‍♀️ 감사합니다!!  