### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 이오(이지우) 미션 제출합니다.

### DIFF
--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1,12 +1,11 @@
 package org.springframework.jdbc.core;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
-import org.springframework.dao.DataAccessException;
 
 public class JdbcTemplate {
 
@@ -17,42 +16,28 @@ public class JdbcTemplate {
     }
 
     public void update(final String sql, final Object... params) {
-        preparedStatementExecutor.execute(sql, preparedStatement -> {
-            try {
-                return preparedStatement.executeUpdate();
-            } catch (final SQLException e) {
-                throw new DataAccessException(e);
-            }
-        }, params);
+        preparedStatementExecutor.execute(sql, PreparedStatement::executeUpdate, params);
     }
 
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... params) {
         return preparedStatementExecutor.execute(sql, pstmt -> {
-            try {
-                final ResultSet rs = pstmt.executeQuery();
-                final List<T> results = new ArrayList<>();
+            final ResultSet rs = pstmt.executeQuery();
+            final List<T> results = new ArrayList<>();
 
-                while (rs.next()) {
-                    results.add(rowMapper.mapRow(rs, rs.getRow()));
-                }
-                return results;
-            } catch (final SQLException e) {
-                throw new DataAccessException(e);
+            while (rs.next()) {
+                results.add(rowMapper.mapRow(rs, rs.getRow()));
             }
+            return results;
         }, params);
     }
 
     public <T> Optional<T> queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... params) {
         return preparedStatementExecutor.execute(sql, pstmt -> {
-            try {
-                final ResultSet rs = pstmt.executeQuery();
-                if (rs.next()) {
-                    return Optional.of(rowMapper.mapRow(rs, rs.getRow()));
-                }
-                return Optional.empty();
-            } catch (final SQLException e) {
-                throw new DataAccessException(e);
+            final ResultSet rs = pstmt.executeQuery();
+            if (rs.next()) {
+                return Optional.of(rowMapper.mapRow(rs, rs.getRow()));
             }
+            return Optional.empty();
         }, params);
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1,77 +1,58 @@
 package org.springframework.jdbc.core;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.jdbc.CannotGetJdbcConnectionException;
+import org.springframework.dao.DataAccessException;
 
 public class JdbcTemplate {
 
-    private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
-
-    private final DataSource dataSource;
+    private final PreparedStatementExecutor preparedStatementExecutor;
 
     public JdbcTemplate(final DataSource dataSource) {
-        this.dataSource = dataSource;
+        this.preparedStatementExecutor = new PreparedStatementExecutor(dataSource);
     }
 
     public void update(final String sql, final Object... params) {
-        try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            log.debug("query : {}", sql);
-
-            for (int i = 0; i < params.length; i++) {
-                pstmt.setObject(i + 1, params[i]);
+        preparedStatementExecutor.execute(sql, preparedStatement -> {
+            try {
+                return preparedStatement.executeUpdate();
+            } catch (final SQLException e) {
+                throw new DataAccessException(e);
             }
-            pstmt.executeUpdate();
-        } catch (final SQLException e) {
-            throw new CannotGetJdbcConnectionException(e.getMessage());
-        }
+        }, params);
     }
 
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... params) {
-        try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql);
-             final ResultSet rs = getResultSet(pstmt, params)) {
-            log.debug("query : {}", sql);
+        return preparedStatementExecutor.execute(sql, pstmt -> {
+            try {
+                final ResultSet rs = pstmt.executeQuery();
+                final List<T> results = new ArrayList<>();
 
-            final List<T> results = new ArrayList<>();
-
-            while (rs.next()) {
-                results.add(rowMapper.mapRow(rs, rs.getRow()));
+                while (rs.next()) {
+                    results.add(rowMapper.mapRow(rs, rs.getRow()));
+                }
+                return results;
+            } catch (final SQLException e) {
+                throw new DataAccessException(e);
             }
-            return results;
-        } catch (final SQLException e) {
-            throw new CannotGetJdbcConnectionException(e.getMessage());
-        }
+        }, params);
     }
 
     public <T> Optional<T> queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... params) {
-        try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql);
-             final ResultSet rs = getResultSet(pstmt, params)) {
-            log.debug("query : {}", sql);
-
-            if (rs.next()) {
-                return Optional.of(rowMapper.mapRow(rs, rs.getRow()));
+        return preparedStatementExecutor.execute(sql, pstmt -> {
+            try {
+                final ResultSet rs = pstmt.executeQuery();
+                if (rs.next()) {
+                    return Optional.of(rowMapper.mapRow(rs, rs.getRow()));
+                }
+                return Optional.empty();
+            } catch (final SQLException e) {
+                throw new DataAccessException(e);
             }
-            return Optional.empty();
-        } catch (final SQLException e) {
-            throw new CannotGetJdbcConnectionException(e.getMessage());
-        }
-    }
-
-    private ResultSet getResultSet(final PreparedStatement pstmt, final Object... params) throws SQLException {
-        for (int i = 0; i < params.length; i++) {
-            pstmt.setObject(i + 1, params[i]);
-        }
-        return pstmt.executeQuery();
+        }, params);
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
@@ -1,0 +1,38 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.function.Function;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.CannotGetJdbcConnectionException;
+
+public class PreparedStatementExecutor {
+    private static final Logger log = LoggerFactory.getLogger(PreparedStatementExecutor.class);
+
+    private final DataSource dataSource;
+
+    public PreparedStatementExecutor(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> T execute(final String sql, final Function<PreparedStatement, T> pstmtFunction, final Object... params) {
+        try (final Connection conn = dataSource.getConnection();
+             final PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            log.debug("query : {}", sql);
+
+            setPreparedStatement(pstmt, params);
+            return pstmtFunction.apply(pstmt);
+        } catch (final SQLException e) {
+            throw new CannotGetJdbcConnectionException(e.getMessage());
+        }
+    }
+
+    private void setPreparedStatement(final PreparedStatement pstmt, final Object... params) throws SQLException {
+        for (int i = 0; i < params.length; i++) {
+            pstmt.setObject(i + 1, params[i]);
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementExecutor.java
@@ -3,7 +3,6 @@ package org.springframework.jdbc.core;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.function.Function;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +17,7 @@ public class PreparedStatementExecutor {
         this.dataSource = dataSource;
     }
 
-    public <T> T execute(final String sql, final Function<PreparedStatement, T> pstmtFunction, final Object... params) {
+    public <T> T execute(final String sql, final PreparedStatementFunction<T> pstmtFunction, final Object... params) {
         try (final Connection conn = dataSource.getConnection();
              final PreparedStatement pstmt = conn.prepareStatement(sql)) {
             log.debug("query : {}", sql);

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementFunction.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementFunction.java
@@ -1,0 +1,10 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementFunction<T> {
+
+    T apply(PreparedStatement pstmt) throws SQLException;
+}


### PR DESCRIPTION
안녕하세요 말랑!

저번 미션에서 대부분의 리팩토링을 진행한 탓에, 이번 미션에서 뭘 해야할지 몰라 고민하다 늦어졌습니다. 🥲
방향을 잡는데 오래걸렸는데, 반복되는 try-catch 문을 제거하는 것이 가장 리팩토링의 효과가 클 것 같아 해당 부분을 진행하였습니다.

처음에는 굳이 커스텀 함수형 인터페이스를 만들 필요가 없다고 생각했는데, SQL exception을 잡지 못하는 탓에 try-catch의 반복을 없앨 수 없더라구요.
그래서 결국 `PreparedStatementExecutor`와 `PreparedStatementFunction`을 추가해 주었습니다.

이번 리뷰도 잘부탁드려요!