### PR TITLE
[JDBC 라이브러리 구현하기 - 2단계] 에코(조은찬) 미션 제출합니다 

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -4,10 +4,9 @@ import com.techcourse.domain.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.SQLParameters;
 
-import java.sql.SQLException;
 import java.util.List;
 
 public class UserDao {
@@ -27,59 +26,40 @@ public class UserDao {
 
     public void insert(final User user) {
         final var sql = "insert into users (account, password, email) values (?, ?, ?)";
-        final SQLParameters sqlParameters = new SQLParameters()
-                .addParameter(user.getAccount())
-                .addParameter(user.getPassword())
-                .addParameter(user.getEmail());
-        try {
-            jdbcTemplate.executeQuery(sql, sqlParameters);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        final PreparedStatementSetter preparedStatementSetter = pstmt -> {
+            pstmt.setString(1, user.getAccount());
+            pstmt.setString(2, user.getPassword());
+            pstmt.setString(3, user.getEmail());
+        };
+        jdbcTemplate.update(sql, preparedStatementSetter);
     }
 
     public void update(final User user) {
         final String sql = "update users set password = ?, email = ? where id = ?";
-        final SQLParameters sqlParameters = new SQLParameters()
-                .addParameter(user.getPassword())
-                .addParameter(user.getEmail())
-                .addParameter(user.getId());
-        try {
-            jdbcTemplate.executeQuery(sql, sqlParameters);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        final PreparedStatementSetter preparedStatementSetter = pstmt -> {
+            pstmt.setString(1, user.getPassword());
+            pstmt.setString(2, user.getEmail());
+            pstmt.setLong(3, user.getId());
+        };
+        jdbcTemplate.update(sql, preparedStatementSetter);
     }
 
     public List<User> findAll() {
         final String sql = "select id, account, password, email from users";
-        try {
-            return jdbcTemplate.query(sql, USER_ROW_MAPPER);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        return jdbcTemplate.query(sql, USER_ROW_MAPPER);
     }
 
     public User findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
-        final SQLParameters sqlParameters = new SQLParameters();
-        sqlParameters.addParameter(id);
-        try {
-            return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, sqlParameters);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        final PreparedStatementSetter preparedStatementSetter = pstmt -> pstmt.setLong(1, id);
+        return jdbcTemplate.query(sql, USER_ROW_MAPPER, preparedStatementSetter);
+
     }
 
 
     public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
-        final SQLParameters sqlParameters = new SQLParameters();
-        sqlParameters.addParameter(account);
-        try {
-            return jdbcTemplate.queryForObject(sql, USER_ROW_MAPPER, sqlParameters);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        final PreparedStatementSetter preparedStatementSetter = pstmt -> pstmt.setString(1, account);
+        return jdbcTemplate.query(sql, USER_ROW_MAPPER, preparedStatementSetter);
     }
 }

--- a/jdbc/build.gradle
+++ b/jdbc/build.gradle
@@ -18,5 +18,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:3.24.2"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.2"
     testImplementation "org.mockito:mockito-core:5.4.0"
+    testImplementation "com.h2database:h2:2.2.220"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.7.2"
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -22,13 +22,13 @@ public class JdbcTemplate {
         this.dataSource = dataSource;
     }
 
-    public void update(final String sql, PreparedStatementSetter preparedStatementSetter) throws DataAccessException {
+    public void update(final String sql, final PreparedStatementSetter preparedStatementSetter) throws DataAccessException {
         try (Connection conn = dataSource.getConnection()) {
             try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
                 preparedStatementSetter.setValues(pstmt);
                 pstmt.executeUpdate();
             }
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             throw new DataAccessException(e);
         }
     }
@@ -43,12 +43,12 @@ public class JdbcTemplate {
                 }
                 throw new DataAccessException("Empty Result");
             }
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             throw new DataAccessException(e);
         }
     }
 
-    private ResultSet executeQuery(final PreparedStatementSetter preparedStatementSetter, PreparedStatement preparedStatement) throws SQLException {
+    private ResultSet executeQuery(final PreparedStatementSetter preparedStatementSetter, final PreparedStatement preparedStatement) throws SQLException {
         preparedStatementSetter.setValues(preparedStatement);
         return preparedStatement.executeQuery();
     }
@@ -62,7 +62,7 @@ public class JdbcTemplate {
                 }
                 throw new DataAccessException("Empty Result");
             }
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             throw new DataAccessException(e);
         }
     }
@@ -84,7 +84,7 @@ public class JdbcTemplate {
                 }
                 return result;
             }
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             throw new DataAccessException(e);
         }
     }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementSetter.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementSetter.java
@@ -1,0 +1,9 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementSetter {
+    void setValues(PreparedStatement ps) throws SQLException;
+}

--- a/jdbc/src/test/java/nextstep/jdbc/DataSourceConfig.java
+++ b/jdbc/src/test/java/nextstep/jdbc/DataSourceConfig.java
@@ -1,0 +1,29 @@
+package nextstep.jdbc;
+
+import org.h2.jdbcx.JdbcDataSource;
+
+import javax.sql.DataSource;
+import java.util.Objects;
+
+public class DataSourceConfig {
+
+    private static DataSource INSTANCE;
+
+    private DataSourceConfig() {
+    }
+
+    public static DataSource getInstance() {
+        if (Objects.isNull(INSTANCE)) {
+            INSTANCE = createJdbcDataSource();
+        }
+        return INSTANCE;
+    }
+
+    private static JdbcDataSource createJdbcDataSource() {
+        final var jdbcDataSource = new JdbcDataSource();
+        jdbcDataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;");
+        jdbcDataSource.setUser("");
+        jdbcDataSource.setPassword("");
+        return jdbcDataSource;
+    }
+}

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -28,7 +28,7 @@ class JdbcTemplateTest {
             final Statement statement = connection.createStatement();
             statement.execute("drop table if exists users");
             statement.execute("create table if not exists users (id bigint auto_increment, account varchar(255), password varchar(255), email varchar(255), primary key (id))");
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             throw new DataAccessException(e);
         }
 

--- a/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/nextstep/jdbc/JdbcTemplateTest.java
@@ -1,5 +1,92 @@
 package nextstep.jdbc;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 class JdbcTemplateTest {
 
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    public void setUp() {
+        final DataSource instance = DataSourceConfig.getInstance();
+        jdbcTemplate = new JdbcTemplate(instance);
+        String sql = "create table if not exists users (id bigint auto_increment, account varchar(255), password varchar(255), email varchar(255), primary key (id))";
+        try (final Connection connection = instance.getConnection()) {
+            final Statement statement = connection.createStatement();
+            statement.execute(sql);
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
+    }
+
+    @Test
+    void update() {
+        //given
+        //when
+        String sql = "insert into users (account, password, email) values (?, ?, ?)";
+        jdbcTemplate.update(sql, preparedStatement -> {
+            preparedStatement.setString(1, "account");
+            preparedStatement.setString(2, "password");
+            preparedStatement.setString(3, "email");
+        });
+
+        //then
+        RowMapper<Map<String, Object>> rowMapper = (resultSet, rowNum) -> Map.of(
+                "id", resultSet.getLong("id"),
+                "account", resultSet.getString("account"),
+                "password", resultSet.getString("password"),
+                "email", resultSet.getString("email")
+        );
+        String selectSql = "select * from users";
+        final List<Map<String, Object>> result = jdbcTemplate.query(selectSql, rowMapper);
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(1);
+            softly.assertThat(result.get(0).get("account")).isEqualTo("account");
+            softly.assertThat(result.get(0).get("password")).isEqualTo("password");
+            softly.assertThat(result.get(0).get("email")).isEqualTo("email");
+        });
+    }
+
+    @Test
+    public void queryList() {
+        //given
+        String sql = "insert into users (account, password, email) values (?, ?, ?)";
+        jdbcTemplate.update(sql, preparedStatement -> {
+            preparedStatement.setString(1, "account");
+            preparedStatement.setString(2, "password");
+            preparedStatement.setString(3, "email");
+        });
+        jdbcTemplate.update(sql, preparedStatement -> {
+            preparedStatement.setString(1, "account2");
+            preparedStatement.setString(2, "password2");
+            preparedStatement.setString(3, "email2");
+        });
+
+        //when
+        String selectSql = "select * from users";
+        final List<Map<String, Object>> result = jdbcTemplate.query(selectSql, (resultSet, rowNum) -> Map.of(
+                "id", resultSet.getLong("id"),
+                "account", resultSet.getString("account"),
+                "password", resultSet.getString("password"),
+                "email", resultSet.getString("email")
+        ));
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(2);
+        });
+    }
 }


### PR DESCRIPTION
안녕하세요 연어!
이번 2단계는 전에 한 것들과 유사해서 크게 수정은 하지 않고 테스트와 PreparedStatementSetter 구현정도로 했던 것 같습니다.
연어 커멘트 달아준 것도 여기다가 적을게요!

### 두 try-with-resources문으로 감쌌을 때와 한 번만 썼을 때는 어떤 차이가 있나요??
→ 차이는 없다고 생각합니다. 다만 인덴트가 하나 더 들어간다? 정도가 있을 것 같고 만약 getConnection과 getPreparedStatement사이에 로직이 들어갈 경우에 그 사이에 넣을 수 있을 것이라 생각했습니다. 딱히 큰 차이는 없는 것 같네요!

### 개발자가 SQLParameters에 넣은 순서대로 setObject가 호출되는 것 같아요.
→ 맞습니다.. 이 부분이 사실 넣은 순서대로 설정을 하니 개발자가 파라미터 순서를 무조건 맞춰서 값을 넣어야하고 그렇지 않을 경우 예외 발생하는 구조인데요, 그래서 예전 기억을 되살려 PreparedStatementSetter 인터페이스를 만들고 그걸 유저가 직접 구현하도록 변경하였습니다!

### 리스트라는 자료구조로 한정하고 있으니 개인적으로 queryForList가 더 좋다고 생각해요!
→ 공식문서를 보면서 메서드 시그니쳐를 정의했는데 공식 문서에 query라는 메서드에 List를 반환하는 메서드가 있더라구요! 그래서 그걸 보고 작성했습니다.
<img width="1471" alt="Screenshot 2023-10-05 at 3 53 07 PM" src="https://github.com/woowacourse/jwp-dashboard-jdbc/assets/50057022/2125331b-97a7-4592-b9e7-62b8bfe9f997">

### rowNum의 용도는 무엇인지 궁금합니다!
→ 저도 사실 실제 jdbc의 RowMapper에 rowNum이 왜 들어가는지 궁금했었는데, [행 번호로 조작할 일이 있을 수 도 있어서 빼지 않고 있다](https://github.com/spring-projects/spring-framework/issues/7796)고 하네요? 저는 기존 JDBC에 있는 rowNum도 그대로 넣고자 넣었었습니다. (물론 현재는 사용할 일이 없지만요)
> After all, RowMapper implementation might use the row number to calculate some position attribute in the mapped objects, for example. The need is rare, but I would argue that if you don't need the rowNum argument, it's easy enough to ignore.