### PR TITLE
[JDBC 라이브러리 구현하기 - 3단계] 지토(김지민) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,62 +1,32 @@
 package com.techcourse.dao;
 
 import com.techcourse.domain.UserHistory;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 public class UserHistoryDao {
 
-    private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
-
-    private final DataSource dataSource;
+    private final JdbcTemplate jdbcTemplate;
 
     public UserHistoryDao(final DataSource dataSource) {
-        this.dataSource = dataSource;
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
-        this.dataSource = null;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public void log(final UserHistory userHistory) {
-        final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
+        final String sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
-
-            log.debug("query : {}", sql);
-
-            pstmt.setLong(1, userHistory.getUserId());
-            pstmt.setString(2, userHistory.getAccount());
-            pstmt.setString(3, userHistory.getPassword());
-            pstmt.setString(4, userHistory.getEmail());
-            pstmt.setObject(5, userHistory.getCreatedAt());
-            pstmt.setString(6, userHistory.getCreateBy());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+        jdbcTemplate.executeQuery(
+                sql,
+                userHistory.getUserId(),
+                userHistory.getAccount(),
+                userHistory.getPassword(),
+                userHistory.getEmail(),
+                userHistory.getCreatedAt(),
+                userHistory.getCreateBy()
+        );
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -4,15 +4,19 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import javax.sql.DataSource;
+import org.springframework.transaction.TransactionTemplate;
 
 public class UserService {
 
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
+    private final TransactionTemplate transactionTemplate;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao, final DataSource dataSource) {
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
+        this.transactionTemplate = new TransactionTemplate(dataSource);
     }
 
     public User findById(final long id) {
@@ -24,9 +28,12 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+        transactionTemplate.executeQueryWithTransaction(() -> {
+            final User user = findById(id);
+
+            user.changePassword(newPassword);
+            userDao.update(user);
+            userHistoryDao.log(new UserHistory(user, createBy));
+        });
     }
 }

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -4,6 +4,7 @@ import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.exception.TransactionTemplateException;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 
@@ -13,6 +14,6 @@ public class MockUserHistoryDao extends UserHistoryDao {
 
     @Override
     public void log(final UserHistory userHistory) {
-        throw new DataAccessException();
+        throw new TransactionTemplateException(new DataAccessException());
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,45 +1,44 @@
 package com.techcourse.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import org.springframework.dao.DataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.exception.TransactionTemplateException;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-@Disabled
 class UserServiceTest {
 
-    private JdbcTemplate jdbcTemplate;
+    private DataSource dataSource;
     private UserDao userDao;
 
     @BeforeEach
     void setUp() {
-        this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
-        this.userDao = new UserDao(jdbcTemplate);
+        this.dataSource = DataSourceConfig.getInstance();
+        this.userDao = new UserDao(dataSource);
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
-        final var user = new User("gugu", "password", "hkkang@woowahan.com");
+        final User user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }
 
     @Test
     void testChangePassword() {
-        final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final UserHistoryDao userHistoryDao = new UserHistoryDao(dataSource);
+        final UserService userService = new UserService(userDao, userHistoryDao, dataSource);
 
-        final var newPassword = "qqqqq";
-        final var createBy = "gugu";
+        final String newPassword = "qqqqq";
+        final String createBy = "gugu";
         userService.changePassword(1L, newPassword, createBy);
 
-        final var actual = userService.findById(1L);
+        final User actual = userService.findById(1L);
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }
@@ -47,16 +46,16 @@ class UserServiceTest {
     @Test
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
-        final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final UserHistoryDao userHistoryDao = new MockUserHistoryDao(new JdbcTemplate(dataSource));
+        final UserService userService = new UserService(userDao, userHistoryDao, dataSource);
 
-        final var newPassword = "newPassword";
-        final var createBy = "gugu";
+        final String newPassword = "newPassword";
+        final String createBy = "gugu";
         // 트랜잭션이 정상 동작하는지 확인하기 위해 의도적으로 MockUserHistoryDao에서 예외를 발생시킨다.
-        assertThrows(DataAccessException.class,
+        assertThrows(TransactionTemplateException.class,
                 () -> userService.changePassword(1L, newPassword, createBy));
 
-        final var actual = userService.findById(1L);
+        final User actual = userService.findById(1L);
 
         assertThat(actual.getPassword()).isNotEqualTo(newPassword);
     }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionContext.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionContext.java
@@ -54,8 +54,7 @@ public final class ConnectionContext {
         try {
             final Connection connection = context.get();
 
-            connection.close();
-            context.remove();
+            closeAndRemove(connection);
         } catch (SQLException e) {
             throw new ConnectionContextException(e);
         }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionContext.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionContext.java
@@ -1,0 +1,83 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.exception.ConnectionContextException;
+
+public final class ConnectionContext {
+
+    private static final ThreadLocal<Connection> context = new ThreadLocal<>();
+
+    public static Connection findConnection(final DataSource dataSource) {
+        final Connection oldConnection = context.get();
+
+        if (oldConnection != null) {
+            return oldConnection;
+        }
+
+        try {
+            final Connection newConnection = dataSource.getConnection();
+
+            context.set(newConnection);
+            return newConnection;
+        } catch (final SQLException e) {
+            throw new ConnectionContextException(e);
+        }
+    }
+
+    public static void setAutoCommit(final Connection connection, final boolean autoCommit) {
+        try {
+            connection.setAutoCommit(autoCommit);
+        } catch (final SQLException e) {
+            throw new ConnectionContextException(e);
+        }
+    }
+
+    public static void commit(final Connection connection) {
+        try {
+            connection.commit();
+        } catch (final SQLException e) {
+            throw new ConnectionContextException(e);
+        }
+    }
+
+    public static void rollback(final Connection connection) {
+        try {
+            connection.rollback();
+        } catch (final SQLException e) {
+            throw new ConnectionContextException(e);
+        }
+    }
+
+    public static void remove() {
+        try {
+            final Connection connection = context.get();
+
+            connection.close();
+            context.remove();
+        } catch (SQLException e) {
+            throw new ConnectionContextException(e);
+        }
+    }
+
+    public static void removeNonTransaction() {
+        try {
+            final Connection connection = context.get();
+
+            closeAndRemove(connection);
+        } catch (final SQLException e) {
+            throw new ConnectionContextException(e);
+        }
+    }
+
+    private static void closeAndRemove(final Connection connection) throws SQLException {
+        if (connection.getAutoCommit()) {
+            connection.close();
+            context.remove();
+        }
+    }
+
+    private ConnectionContext() {
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -9,8 +9,6 @@ import org.springframework.jdbc.core.exception.MultipleDataAccessException;
 
 public class JdbcTemplate {
 
-    private static final int START_STATEMENT_INDEX = 1;
-
     private final PreparedStatementTemplate preparedStatementTemplate;
     private final ResultSetTemplate resultSetTemplate;
 
@@ -21,8 +19,9 @@ public class JdbcTemplate {
 
     public int executeQuery(final String sql, final Object... statements) {
         return preparedStatementTemplate.execute(
-                connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
-                PreparedStatement::executeUpdate
+                connection -> connection.prepareStatement(sql),
+                PreparedStatement::executeUpdate,
+                statements
         );
     }
 
@@ -46,8 +45,9 @@ public class JdbcTemplate {
         };
 
         return preparedStatementTemplate.execute(
-                connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
-                preparedStatement -> resultSetTemplate.execute(preparedStatement, resultSetMapper)
+                connection -> connection.prepareStatement(sql),
+                preparedStatement -> resultSetTemplate.execute(preparedStatement, resultSetMapper),
+                statements
         );
     }
 
@@ -67,18 +67,9 @@ public class JdbcTemplate {
         };
 
         return preparedStatementTemplate.execute(
-                connection -> bindStatements().bind(connection.prepareStatement(sql), statements),
-                preparedStatement -> resultSetTemplate.execute(preparedStatement, resultSetMapper)
+                connection -> connection.prepareStatement(sql),
+                preparedStatement -> resultSetTemplate.execute(preparedStatement, resultSetMapper),
+                statements
         );
-    }
-
-    private PreparedStatementBinder bindStatements() {
-        return (preparedStatement, statements) -> {
-            for (int i = START_STATEMENT_INDEX; i < statements.length + 1; i++) {
-                preparedStatement.setObject(i, statements[i - START_STATEMENT_INDEX]);
-            }
-
-            return preparedStatement;
-        };
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementTemplate.java
@@ -8,6 +8,8 @@ import org.springframework.jdbc.core.exception.PreparedStatementTemplateExceptio
 
 public class PreparedStatementTemplate {
 
+    private static final int START_STATEMENT_INDEX = 1;
+
     private final DataSource dataSource;
 
     public PreparedStatementTemplate(final DataSource dataSource) {
@@ -16,15 +18,34 @@ public class PreparedStatementTemplate {
 
     public <T> T execute(
             final PreparedStatementCreator creator,
-            final PreparedStatementExecutor<T> executor
+            final PreparedStatementExecutor<T> executor,
+            final Object... statements
     ) {
         try (
                 final Connection connection = dataSource.getConnection();
-                final PreparedStatement preparedStatement = creator.create(connection)
+                final PreparedStatement preparedStatement = processPreparedStatement(connection, creator, statements)
         ) {
             return executor.execute(preparedStatement);
         } catch (final SQLException e) {
             throw new PreparedStatementTemplateException(e);
         }
+    }
+
+    private PreparedStatement processPreparedStatement(
+            final Connection connection,
+            final PreparedStatementCreator creator,
+            final Object... statements
+    ) throws SQLException {
+        return bindStatements().bind(creator.create(connection), statements);
+    }
+
+    private PreparedStatementBinder bindStatements() {
+        return (preparedStatement, statements) -> {
+            for (int i = START_STATEMENT_INDEX; i < statements.length + 1; i++) {
+                preparedStatement.setObject(i, statements[i - START_STATEMENT_INDEX]);
+            }
+
+            return preparedStatement;
+        };
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementTemplate.java
@@ -21,13 +21,16 @@ public class PreparedStatementTemplate {
             final PreparedStatementExecutor<T> executor,
             final Object... statements
     ) {
+        final Connection connection = ConnectionContext.findConnection(dataSource);
+
         try (
-                final Connection connection = dataSource.getConnection();
                 final PreparedStatement preparedStatement = processPreparedStatement(connection, creator, statements)
         ) {
             return executor.execute(preparedStatement);
         } catch (final SQLException e) {
             throw new PreparedStatementTemplateException(e);
+        } finally {
+            ConnectionContext.removeNonTransaction();
         }
     }
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/exception/ConnectionContextException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/exception/ConnectionContextException.java
@@ -1,6 +1,8 @@
 package org.springframework.jdbc.core.exception;
 
-public class ConnectionContextException extends RuntimeException {
+import org.springframework.dao.DataAccessException;
+
+public class ConnectionContextException extends DataAccessException {
 
     public ConnectionContextException(final Throwable cause) {
         super(cause);

--- a/jdbc/src/main/java/org/springframework/jdbc/core/exception/ConnectionContextException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/exception/ConnectionContextException.java
@@ -1,0 +1,8 @@
+package org.springframework.jdbc.core.exception;
+
+public class ConnectionContextException extends RuntimeException {
+
+    public ConnectionContextException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/exception/JdbcTemplateException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/exception/JdbcTemplateException.java
@@ -1,8 +1,0 @@
-package org.springframework.jdbc.core.exception;
-
-public class JdbcTemplateException extends RuntimeException {
-
-    public JdbcTemplateException(final Throwable cause) {
-        super(cause);
-    }
-}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/exception/MultipleDataAccessException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/exception/MultipleDataAccessException.java
@@ -1,6 +1,8 @@
 package org.springframework.jdbc.core.exception;
 
-public class MultipleDataAccessException extends RuntimeException {
+import org.springframework.dao.DataAccessException;
+
+public class MultipleDataAccessException extends DataAccessException {
 
     public MultipleDataAccessException(final String message) {
         super(message);

--- a/jdbc/src/main/java/org/springframework/jdbc/core/exception/PreparedStatementTemplateException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/exception/PreparedStatementTemplateException.java
@@ -1,6 +1,8 @@
 package org.springframework.jdbc.core.exception;
 
-public class PreparedStatementTemplateException extends RuntimeException {
+import org.springframework.dao.DataAccessException;
+
+public class PreparedStatementTemplateException extends DataAccessException {
 
     public PreparedStatementTemplateException(final Throwable cause) {
         super(cause);

--- a/jdbc/src/main/java/org/springframework/jdbc/core/exception/ResultSetTemplateException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/exception/ResultSetTemplateException.java
@@ -1,6 +1,8 @@
 package org.springframework.jdbc.core.exception;
 
-public class ResultSetTemplateException extends RuntimeException {
+import org.springframework.dao.DataAccessException;
+
+public class ResultSetTemplateException extends DataAccessException {
 
     public ResultSetTemplateException(final Throwable cause) {
         super(cause);

--- a/jdbc/src/main/java/org/springframework/transaction/TransactionTemplate.java
+++ b/jdbc/src/main/java/org/springframework/transaction/TransactionTemplate.java
@@ -1,0 +1,51 @@
+package org.springframework.transaction;
+
+import java.sql.Connection;
+import javax.sql.DataSource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ConnectionContext;
+import org.springframework.transaction.exception.TransactionTemplateException;
+
+public class TransactionTemplate {
+
+    private final DataSource dataSource;
+
+    public TransactionTemplate(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> T executeQueryWithTransaction(final TransactionalCallbackWithReturnValue<T> callback) {
+        final Connection connection = ConnectionContext.findConnection(dataSource);
+
+        try {
+            ConnectionContext.setAutoCommit(connection, false);
+
+            final T result = callback.execute();
+
+            ConnectionContext.commit(connection);
+            return result;
+        } catch (final DataAccessException e) {
+            ConnectionContext.rollback(connection);
+
+            throw new TransactionTemplateException(e);
+        } finally {
+            ConnectionContext.remove();
+        }
+    }
+
+    public void executeQueryWithTransaction(final TransactionalCallbackWithoutReturnValue callback) {
+        final Connection connection = ConnectionContext.findConnection(dataSource);
+
+        try {
+            ConnectionContext.setAutoCommit(connection, false);
+            callback.execute();
+            ConnectionContext.commit(connection);
+        } catch (final RuntimeException e) {
+            ConnectionContext.rollback(connection);
+
+            throw new TransactionTemplateException(e);
+        } finally {
+            ConnectionContext.remove();
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/transaction/TransactionalCallbackWithReturnValue.java
+++ b/jdbc/src/main/java/org/springframework/transaction/TransactionalCallbackWithReturnValue.java
@@ -1,0 +1,7 @@
+package org.springframework.transaction;
+
+@FunctionalInterface
+public interface TransactionalCallbackWithReturnValue<T> {
+
+    T execute();
+}

--- a/jdbc/src/main/java/org/springframework/transaction/TransactionalCallbackWithoutReturnValue.java
+++ b/jdbc/src/main/java/org/springframework/transaction/TransactionalCallbackWithoutReturnValue.java
@@ -1,0 +1,7 @@
+package org.springframework.transaction;
+
+@FunctionalInterface
+public interface TransactionalCallbackWithoutReturnValue {
+
+    void execute();
+}

--- a/jdbc/src/main/java/org/springframework/transaction/exception/TransactionTemplateException.java
+++ b/jdbc/src/main/java/org/springframework/transaction/exception/TransactionTemplateException.java
@@ -1,0 +1,8 @@
+package org.springframework.transaction.exception;
+
+public class TransactionTemplateException extends RuntimeException {
+
+    public TransactionTemplateException(final Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
안녕하세요 오리 
이번 3단계는 트랜잭션 관련 강의에서 언급된 Programmatic Transaction Management에서 아이디어를 얻어서 진행했습니다 

트랜잭션의 경우 기존과 유사하게 TransactionTemplate라는 클래스를 만들어 템플릿 패턴을 사용했고 하나의 트랜잭션에서 수행할 로직의 묶음은 함수형 인터페이스로 처리했습니다
이 함수형 인터페이스는 반환값이 없는 경우와 있는 경우 두 가지로 분리했습니다

각 Dao가 동일한 커넥션을 사용할 수 있도록 ConnectionContext라는 클래스를 만들고, 내부적으로는 ThreadLocal을 활용하도록 했습니다 
이로 인해 같은 커넥션을 사용할 수는 있게 되었지만, PreparedStatementTemplate과 같은 기존 코드에서는 이 커넥션이 언제 close되어야 하는지 알 수 없어서 try-with-resource에서 커넥션을 제거하고, ThreadLocal의 값을 제거하기 전에 커넥션을 꺼내서 close 해주는 식으로 진행했습니다

이번 리뷰도 잘 부탁드립니다 