### PR TITLE
JDBC 라이브러리 구현하기 - 2단계] 이레(이다형) 미션 제출합니다. 

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -47,7 +47,7 @@ public class UserDao {
     }
 
     public User findById(final Long id) {
-        final var sql = "select id, account, password, email from users where id = ?";
+        final var sql = "select * from users where id = ?";
         Optional<User> user = jdbcTemplate.queryForObject(sql, USER_MAPPER, id);
         return user.orElseThrow(() -> new RuntimeException());
     }

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -1,18 +1,13 @@
 package com.techcourse.dao;
 
 import com.techcourse.domain.User;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
 import javax.sql.DataSource;
 import java.util.List;
-import java.util.Optional;
 
 public class UserDao {
-
-    private static final Logger log = LoggerFactory.getLogger(UserDao.class);
 
     private static final RowMapper<User> USER_MAPPER = (rs) -> new User(
             rs.getLong(1),
@@ -48,13 +43,11 @@ public class UserDao {
 
     public User findById(final Long id) {
         final var sql = "select * from users where id = ?";
-        Optional<User> user = jdbcTemplate.queryForObject(sql, USER_MAPPER, id);
-        return user.orElseThrow(() -> new RuntimeException());
+        return jdbcTemplate.queryForObject(sql, USER_MAPPER, id);
     }
 
     public User findByAccount(final String account) {
         final var sql = "select * from users where account = ?";
-        Optional<User> user = jdbcTemplate.queryForObject(sql, USER_MAPPER, account);
-        return user.orElseThrow(() -> new RuntimeException());
+        return jdbcTemplate.queryForObject(sql, USER_MAPPER, account);
     }
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -3,22 +3,34 @@ package com.techcourse.dao;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UserDaoTest {
 
     private UserDao userDao;
+    private DataSource dataSource;
 
     @BeforeEach
     void setup() {
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+        dataSource = DataSourceConfig.getInstance();
+        DatabasePopulatorUtils.execute(dataSource);
 
-        userDao = new UserDao(DataSourceConfig.getInstance());
+        userDao = new UserDao(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
+    }
+
+    @AfterEach
+    void after() {
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.update("TRUNCATE TABLE users RESTART IDENTITY");
     }
 
     @Test

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -27,13 +27,17 @@ public class JdbcTemplate {
              final PreparedStatement pstmt = conn.prepareStatement(sql)) {
             log.debug("query : {}", sql);
 
-            for (int i = 0; i < args.length; i++) {
-                pstmt.setObject(i + 1, args[i]);
-            }
+            bindParameterWithStatement(pstmt, args);
             pstmt.executeUpdate();
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
             throw new RuntimeException(e);
+        }
+    }
+
+    private static void bindParameterWithStatement(final PreparedStatement pstmt, final Object[] args) throws SQLException {
+        for (int i = 0; i < args.length; i++) {
+            pstmt.setObject(i + 1, args[i]);
         }
     }
 
@@ -42,10 +46,8 @@ public class JdbcTemplate {
              final PreparedStatement pstmt = conn.prepareStatement(sql)) {
             log.debug("query : {}", sql);
 
-            for (int i = 0; i < args.length; i++) {
-                pstmt.setObject(i + 1, args[i]);
-            }
-            ResultSet resultSet = pstmt.executeQuery();
+            bindParameterWithStatement(pstmt, args);
+            final ResultSet resultSet = pstmt.executeQuery();
             if (resultSet.next()) {
                 return Optional.of(rowMapper.mapRow(resultSet));
             }
@@ -61,11 +63,10 @@ public class JdbcTemplate {
              final PreparedStatement pstmt = conn.prepareStatement(sql)) {
             log.debug("query : {}", sql);
 
-            for (int i = 0; i < args.length; i++) {
-                pstmt.setObject(i + 1, args[i]);
-            }
-            ResultSet resultSet = pstmt.executeQuery();
-            List<T> result = new ArrayList<>();
+            bindParameterWithStatement(pstmt, args);
+
+            final ResultSet resultSet = pstmt.executeQuery();
+            final List<T> result = new ArrayList<>();
             while (resultSet.next()) {
                 result.add(rowMapper.mapRow(resultSet));
             }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -2,6 +2,7 @@ package org.springframework.jdbc.core;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -10,7 +11,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class JdbcTemplate {
 
@@ -23,57 +23,42 @@ public class JdbcTemplate {
     }
 
     public void update(final String sql, final Object... args) {
-        try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            log.debug("query : {}", sql);
-
-            bindParameterWithStatement(pstmt, args);
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        }
+        execute(sql, args, PreparedStatement::executeUpdate);
     }
 
-    private static void bindParameterWithStatement(final PreparedStatement pstmt, final Object[] args) throws SQLException {
-        for (int i = 0; i < args.length; i++) {
-            pstmt.setObject(i + 1, args[i]);
-        }
-    }
-
-    public <T> Optional<T> queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
-        try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            log.debug("query : {}", sql);
-
-            bindParameterWithStatement(pstmt, args);
-            final ResultSet resultSet = pstmt.executeQuery();
+    public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
+        return execute(sql, args, (PreparedStatement pstmt) -> {
+            ResultSet resultSet = pstmt.executeQuery();
             if (resultSet.next()) {
-                return Optional.of(rowMapper.mapRow(resultSet));
+                return rowMapper.mapRow(resultSet);
             }
-            return Optional.empty();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        }
+            throw new RuntimeException();
+        });
     }
 
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... args) {
-        try (final Connection conn = dataSource.getConnection();
-             final PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            log.debug("query : {}", sql);
-
-            bindParameterWithStatement(pstmt, args);
-
-            final ResultSet resultSet = pstmt.executeQuery();
+        return execute(sql, args, (PreparedStatement pstmt) -> {
+            ResultSet resultSet = pstmt.executeQuery();
             final List<T> result = new ArrayList<>();
             while (resultSet.next()) {
                 result.add(rowMapper.mapRow(resultSet));
             }
             return result;
+        });
+    }
+
+    private <T> T execute(final String sql, final Object[] args, final PreparedStatementFunction<T> preparedStatementExecutor) {
+        try (final Connection conn = dataSource.getConnection();
+             final PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            log.debug("query : {}", sql);
+
+            for (int i = 0; i < args.length; i++) {
+                pstmt.setObject(i + 1, args[i]);
+            }
+            return preparedStatementExecutor.execute(pstmt);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
+            throw new DataAccessException(e);
         }
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementFunction.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/PreparedStatementFunction.java
@@ -1,0 +1,10 @@
+package org.springframework.jdbc.core;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface PreparedStatementFunction<T>{
+
+    T execute(PreparedStatement pstmt) throws SQLException;
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/exception/EmptyResultDataAccessException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/exception/EmptyResultDataAccessException.java
@@ -1,0 +1,7 @@
+package org.springframework.jdbc.exception;
+
+public class EmptyResultDataAccessException extends IncorrectResultSizeDataAccessException {
+    public EmptyResultDataAccessException(final int i) {
+        super(i,0);
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/exception/IncorrectResultSizeDataAccessException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/exception/IncorrectResultSizeDataAccessException.java
@@ -1,0 +1,9 @@
+package org.springframework.jdbc.exception;
+
+import org.springframework.dao.DataAccessException;
+
+public class IncorrectResultSizeDataAccessException extends DataAccessException {
+    public IncorrectResultSizeDataAccessException(int expected, int actual) {
+        super("Incorrect result size: expected " + expected + ", actual " + actual);
+    }
+}


### PR DESCRIPTION
안녕하세요 저문! 이레입니다
추석과 재택근무 기간 잘 보내셨나요?
저는 추석과 재택근무를 너무 신나게 즐긴 나머지 너무 늦은 리뷰요청을 보내게 되었습니다...
3,4단계는 빠르게 리뷰요청 보내도록 하겠습니다. 

## 코드 작성 시 중점적으로 고려한 점
1. try-resources-with의 중복 제거
   함수형 인터페이스와 람다식의 사용으로 중복을 제거하는 데 초점을 맞추어 코드를 작성했습니다.
2. JdbcTemplate와 DAO의 책임 분리 : `queryForObject`
    JdbcTemplate의 `queryForObject`의 경우 단일 객체 조회라는 책임을 가진 메서드로, 단일 객체를 조회하지 못하면 예외를 발생시켜야한다고 생각했습니다.
    JdbcTemplate에서 단일 객체를 조회하지 못해서 발생하는 예외(DataAccessException)는 DAO가 처리하는 것이 JdbcTemplate와 DAO의 책임을 명확하게 분리하는 것이라고 판단해 코드륵 작성했습니다.
3. UserDaoTest의 격리성 
    queryForObject의 예외를 (0개를 조회한 경우) (n>1을 조회한 경우) 로 구체화 시켜 처리하는 과정에서, UserDaoTest가 통과되지 못하는 상황이 발생하였습니다. 원인은 UserDaoTest의 각각의 테스트들이 inser문을 반복함으로써 격리성을 지키지 못했다는 것이었는데요. 따라서 매 테스트마다 truncat ddl문을 실행시킴으로써 각각의 테스트를 격리하도록 했습니다.

## 궁금한 점
메서드를 추출하면서 코드를 작성하는 과정에서 이해가 안가는 점을 발견했는데.
PreparedStatementFunction<T> 함수형 인터페이스에서 execute는 T를 반환하는데, 
JdbcTemplate클래스
`<T> List<T> query(final String sql, final RowMapper<T> rowMapper, final Object... args) { ... } `
메서드 내부의 execute() 메서드는 List<T>를 반환하는데도 문제가 발생하지 않더라구요. 혹시 이유를 아시나요?