### PR TITLE
[JDBC 라이브러리 구현하기 - 3단계] 포이(김보준) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,6 +1,5 @@
 package com.techcourse.service;
 
-import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
@@ -28,10 +27,7 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        transactionManager.doInTransaction(
-                () -> doChangePassword(id, newPassword, createBy),
-                DataSourceConfig.getInstance()
-        );
+        transactionManager.doInTransaction(() -> doChangePassword(id, newPassword, createBy));
     }
 
     private void doChangePassword(final long id, final String newPassword, final String createBy) {

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,18 +1,22 @@
 package com.techcourse.service;
 
+import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import org.springframework.transaction.support.TransactionManager;
 
 public class UserService {
 
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
+    private final TransactionManager transactionManager;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao, final TransactionManager transactionManager) {
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
+        this.transactionManager = transactionManager;
     }
 
     public User findById(final long id) {
@@ -24,6 +28,13 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
+        transactionManager.doInTransaction(
+                () -> doChangePassword(id, newPassword, createBy),
+                DataSourceConfig.getInstance()
+        );
+    }
+
+    private void doChangePassword(final long id, final String newPassword, final String createBy) {
         final var user = findById(id);
         user.changePassword(newPassword);
         userDao.update(user);

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -23,7 +23,7 @@ class UserServiceTest {
     @BeforeEach
     void setUp() {
         this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
-        this.transactionManager = new TransactionManager();
+        this.transactionManager = new TransactionManager(DataSourceConfig.getInstance());
         this.userDao = new UserDao(jdbcTemplate);
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -8,21 +8,22 @@ import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
+    private TransactionManager transactionManager;
     private UserDao userDao;
 
     @BeforeEach
     void setUp() {
         this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        this.transactionManager = new TransactionManager();
         this.userDao = new UserDao(jdbcTemplate);
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
@@ -33,7 +34,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, transactionManager);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -48,7 +49,7 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, transactionManager);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -7,7 +7,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.springframework.dao.DataAccessException;
-import org.springframework.jdbc.CannotGetJdbcConnectionException;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 
 public class JdbcTemplate {
 
@@ -78,10 +78,9 @@ public class JdbcTemplate {
             final PreparedStatementCreator psc,
             final PreparedStatementCallback<T> action
     ) throws DataAccessException {
-        try (
-                final var conn = getConnection();
-                final var ps = psc.createPreparedStatement(conn, sql)
-        ) {
+        try {
+            final var conn = getConnection();
+            final var ps = psc.createPreparedStatement(conn, sql);
             return action.doInPreparedStatement(ps);
         } catch (SQLException e) {
             throw new DataAccessException(e.getSQLState());
@@ -89,10 +88,6 @@ public class JdbcTemplate {
     }
 
     private Connection getConnection() {
-        try {
-            return dataSource.getConnection();
-        } catch (SQLException e) {
-            throw new CannotGetJdbcConnectionException(e.getMessage(), e);
-        }
+        return DataSourceUtils.getConnection(dataSource);
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -83,7 +83,9 @@ public class JdbcTemplate {
             final var ps = psc.createPreparedStatement(conn, sql);
             return action.doInPreparedStatement(ps);
         } catch (SQLException e) {
-            throw new DataAccessException(e.getSQLState());
+            throw new DataAccessException(e.getMessage());
+        } finally {
+            DataSourceUtils.releaseConnection(getConnection(), dataSource);
         }
     }
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -78,9 +78,7 @@ public class JdbcTemplate {
             final PreparedStatementCreator psc,
             final PreparedStatementCallback<T> action
     ) throws DataAccessException {
-        try {
-            final var conn = getConnection();
-            final var ps = psc.createPreparedStatement(conn, sql);
+        try (final var ps = psc.createPreparedStatement(getConnection(), sql)) {
             return action.doInPreparedStatement(ps);
         } catch (SQLException e) {
             throw new DataAccessException(e.getMessage());

--- a/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
@@ -10,10 +10,10 @@ import java.sql.SQLException;
 // 4단계 미션에서 사용할 것
 public abstract class DataSourceUtils {
 
-    private DataSourceUtils() {}
+    private DataSourceUtils() {
+    }
 
-    public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
-        TransactionSynchronizationManager.initSynchronization();
+    public static Connection getConnection(final DataSource dataSource) throws CannotGetJdbcConnectionException {
         Connection connection = TransactionSynchronizationManager.getResource(dataSource);
         if (connection != null) {
             return connection;
@@ -21,19 +21,25 @@ public abstract class DataSourceUtils {
 
         try {
             connection = dataSource.getConnection();
-            TransactionSynchronizationManager.bindResource(dataSource, connection);
             return connection;
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to obtain JDBC Connection", ex);
         }
     }
 
-    public static void releaseConnection(Connection connection, DataSource dataSource) {
+    public static void releaseConnection(final Connection connection, final DataSource dataSource) {
+        if (isInTransaction(connection, dataSource)) {
+            return;
+        }
+
         try {
-            TransactionSynchronizationManager.unbindResource(dataSource);
             connection.close();
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to close JDBC Connection");
         }
+    }
+
+    private static boolean isInTransaction(final Connection connection, final DataSource dataSource) {
+        return TransactionSynchronizationManager.getResource(dataSource) == connection;
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
@@ -13,6 +13,7 @@ public abstract class DataSourceUtils {
     private DataSourceUtils() {}
 
     public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
+        TransactionSynchronizationManager.initSynchronization();
         Connection connection = TransactionSynchronizationManager.getResource(dataSource);
         if (connection != null) {
             return connection;
@@ -29,6 +30,7 @@ public abstract class DataSourceUtils {
 
     public static void releaseConnection(Connection connection, DataSource dataSource) {
         try {
+            TransactionSynchronizationManager.unbindResource(dataSource);
             connection.close();
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to close JDBC Connection");

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionManager.java
@@ -13,17 +13,16 @@ public class TransactionManager {
         this.dataSource = dataSource;
     }
 
-    public void doInTransaction(Runnable runnable) {
-        TransactionSynchronizationManager.initSynchronization();
-        final var connection = DataSourceUtils.getConnection(dataSource);
-        try {
+    public void doInTransaction(final Runnable runnable) {
+        try (final var connection = DataSourceUtils.getConnection(dataSource)) {
+            TransactionSynchronizationManager.bindResource(dataSource, connection);
             connection.setAutoCommit(false);
             runnable.run();
             connection.commit();
         } catch (SQLException e) {
             throw new DataAccessException(e.getMessage());
         } finally {
-            DataSourceUtils.releaseConnection(connection, dataSource);
+            TransactionSynchronizationManager.unbindResource(dataSource);
         }
     }
 }

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionManager.java
@@ -7,10 +7,13 @@ import org.springframework.jdbc.datasource.DataSourceUtils;
 
 public class TransactionManager {
 
-    public TransactionManager() {
+    private final DataSource dataSource;
+
+    public TransactionManager(final DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
-    public void doInTransaction(Runnable runnable, DataSource dataSource) {
+    public void doInTransaction(Runnable runnable) {
         TransactionSynchronizationManager.initSynchronization();
         final var connection = DataSourceUtils.getConnection(dataSource);
         try {

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionManager.java
@@ -1,0 +1,26 @@
+package org.springframework.transaction.support;
+
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+
+public class TransactionManager {
+
+    public TransactionManager() {
+    }
+
+    public void doInTransaction(Runnable runnable, DataSource dataSource) {
+        TransactionSynchronizationManager.initSynchronization();
+        final var connection = DataSourceUtils.getConnection(dataSource);
+        try {
+            connection.setAutoCommit(false);
+            runnable.run();
+            connection.commit();
+        } catch (SQLException e) {
+            throw new DataAccessException(e.getMessage());
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
@@ -1,5 +1,6 @@
 package org.springframework.transaction.support;
 
+import java.util.HashMap;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.util.Map;
@@ -8,16 +9,24 @@ public abstract class TransactionSynchronizationManager {
 
     private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
 
-    private TransactionSynchronizationManager() {}
+    private TransactionSynchronizationManager() {
+    }
+
+    public static void initSynchronization() {
+        if (resources.get() == null) {
+            resources.set(new HashMap<>());
+        }
+    }
 
     public static Connection getResource(DataSource key) {
-        return null;
+        return resources.get().get(key);
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        resources.get().put(key, value);
     }
 
     public static Connection unbindResource(DataSource key) {
-        return null;
+        return resources.get().remove(key);
     }
 }

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
@@ -1,9 +1,9 @@
 package org.springframework.transaction.support;
 
-import java.util.HashMap;
-import javax.sql.DataSource;
 import java.sql.Connection;
+import java.util.HashMap;
 import java.util.Map;
+import javax.sql.DataSource;
 
 public abstract class TransactionSynchronizationManager {
 
@@ -12,21 +12,26 @@ public abstract class TransactionSynchronizationManager {
     private TransactionSynchronizationManager() {
     }
 
-    public static void initSynchronization() {
+    public static Connection getResource(final DataSource key) {
+        return getThreadLocalResource().get(key);
+    }
+
+    public static void bindResource(final DataSource key, final Connection value) {
+        getThreadLocalResource().put(key, value);
+    }
+
+    public static Connection unbindResource(final DataSource key) {
+        return getThreadLocalResource().remove(key);
+    }
+
+    private static Map<DataSource, Connection> getThreadLocalResource() {
         if (resources.get() == null) {
-            resources.set(new HashMap<>());
+            initSynchronization();
         }
+        return resources.get();
     }
 
-    public static Connection getResource(DataSource key) {
-        return resources.get().get(key);
-    }
-
-    public static void bindResource(DataSource key, Connection value) {
-        resources.get().put(key, value);
-    }
-
-    public static Connection unbindResource(DataSource key) {
-        return resources.get().remove(key);
+    private static void initSynchronization() {
+        resources.set(new HashMap<>());
     }
 }

--- a/study/src/main/java/transaction/DatabasePopulatorUtils.java
+++ b/study/src/main/java/transaction/DatabasePopulatorUtils.java
@@ -1,5 +1,7 @@
 package transaction;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,10 +23,13 @@ public class DatabasePopulatorUtils {
         try {
             final var url = DatabasePopulatorUtils.class.getClassLoader().getResource("schema.sql");
             final var file = new File(url.getFile());
-            final var sql = Files.readString(file.toPath());
+            final var fileString = Files.readString(file.toPath());
+            final var sqls = Arrays.stream(fileString.split(";")).collect(Collectors.toList());
             connection = dataSource.getConnection();
             statement = connection.createStatement();
-            statement.execute(sql);
+            for (final var sql : sqls) {
+                statement.execute(sql);
+            }
         } catch (NullPointerException | IOException | SQLException e) {
             log.error(e.getMessage(), e.getCause());
         } finally {

--- a/study/src/test/java/transaction/stage1/Stage1Test.java
+++ b/study/src/test/java/transaction/stage1/Stage1Test.java
@@ -34,10 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   Read phenomena | Dirty reads | Non-repeatable reads | Phantom reads
  * Isolation level  |             |                      |
  * -----------------|-------------|----------------------|--------------
- * Read Uncommitted |             |                      |
- * Read Committed   |             |                      |
- * Repeatable Read  |             |                      |
- * Serializable     |             |                      |
+ * Read Uncommitted |      +      |           +          |      +
+ * Read Committed   |      -      |           +          |      +
+ * Repeatable Read  |      -      |           -          |      +
+ * Serializable     |      -      |           -          |      -
  */
 class Stage1Test {
 
@@ -58,10 +58,10 @@ class Stage1Test {
      *   Read phenomena | Dirty reads
      * Isolation level  |
      * -----------------|-------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |       +
+     * Read Committed   |       -
+     * Repeatable Read  |       -
+     * Serializable     |       -
      */
     @Test
     void dirtyReading() throws SQLException {
@@ -81,7 +81,7 @@ class Stage1Test {
             final var subConnection = dataSource.getConnection();
 
             // 적절한 격리 레벨을 찾는다.
-            final int isolationLevel = Connection.TRANSACTION_NONE;
+            final int isolationLevel = Connection.TRANSACTION_READ_COMMITTED;
 
             // 트랜잭션 격리 레벨을 설정한다.
             subConnection.setTransactionIsolation(isolationLevel);
@@ -111,10 +111,10 @@ class Stage1Test {
      *   Read phenomena | Non-repeatable reads
      * Isolation level  |
      * -----------------|---------------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |       +
+     * Read Committed   |       +
+     * Repeatable Read  |       -
+     * Serializable     |       -
      */
     @Test
     void noneRepeatable() throws SQLException {
@@ -130,7 +130,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -154,7 +154,7 @@ class Stage1Test {
         sleep(0.5);
 
         // 사용자A가 다시 gugu 객체를 조회했다.
-        // 사용자B는 패스워드를 변경하고 아직 커밋하지 않았다.
+        // 사용자B는 패스워드를 변경하고 아직 커밋하지 않았다.???
         final var actual = userDao.findByAccount(connection, "gugu");
 
         // 트랜잭션 격리 레벨에 따라 아래 테스트가 통과한다.
@@ -173,10 +173,10 @@ class Stage1Test {
      *   Read phenomena | Phantom reads
      * Isolation level  |
      * -----------------|--------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |       +
+     * Read Committed   |       +
+     * Repeatable Read  |       +
+     * Serializable     |       -
      */
     @Test
     void phantomReading() throws SQLException {
@@ -197,7 +197,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_SERIALIZABLE;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);

--- a/study/src/test/java/transaction/stage2/FirstUserService.java
+++ b/study/src/test/java/transaction/stage2/FirstUserService.java
@@ -66,7 +66,7 @@ public class FirstUserService {
         throw new RuntimeException();
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithSupports() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -77,7 +77,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithMandatory() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -99,7 +99,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNested() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -110,7 +110,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNever() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());

--- a/study/src/test/java/transaction/stage2/FirstUserService.java
+++ b/study/src/test/java/transaction/stage2/FirstUserService.java
@@ -1,5 +1,10 @@
 package transaction.stage2;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,12 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 public class FirstUserService {
@@ -110,7 +109,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNever() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());

--- a/study/src/test/java/transaction/stage2/Stage2Test.java
+++ b/study/src/test/java/transaction/stage2/Stage2Test.java
@@ -45,8 +45,8 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.FirstUserService.saveFirstTransactionWithRequired");
     }
 
     /**
@@ -59,8 +59,9 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(2)
+                .containsExactlyInAnyOrder("transaction.stage2.FirstUserService.saveFirstTransactionWithRequiredNew"
+                , "transaction.stage2.SecondUserService.saveSecondTransactionWithRequiresNew");
     }
 
     /**
@@ -69,12 +70,12 @@ class Stage2Test {
      */
     @Test
     void testRequiredNewWithRollback() {
-        assertThat(firstUserService.findAll()).hasSize(-1);
+        assertThat(firstUserService.findAll()).hasSize(0);
 
         assertThatThrownBy(() -> firstUserService.saveAndExceptionWithRequiredNew())
                 .isInstanceOf(RuntimeException.class);
 
-        assertThat(firstUserService.findAll()).hasSize(-1);
+        assertThat(firstUserService.findAll()).hasSize(1);
     }
 
     /**
@@ -87,8 +88,8 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.FirstUserService.saveFirstTransactionWithSupports");
     }
 
     /**
@@ -102,8 +103,8 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.FirstUserService.saveFirstTransactionWithMandatory");
     }
 
     /**
@@ -119,8 +120,9 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(2)
+                .containsExactlyInAnyOrder("transaction.stage2.FirstUserService.saveFirstTransactionWithNotSupported"
+                        , "transaction.stage2.SecondUserService.saveSecondTransactionWithNotSupported");
     }
 
     /**
@@ -133,8 +135,8 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.SecondUserService.saveSecondTransactionWithNested");
     }
 
     /**
@@ -146,7 +148,7 @@ class Stage2Test {
 
         log.info("transactions : {}", actual);
         assertThat(actual)
-                .hasSize(0)
-                .containsExactly("");
+                .hasSize(1)
+                .containsExactly("transaction.stage2.SecondUserService.saveSecondTransactionWithNever");
     }
 }

--- a/study/src/test/resources/schema.sql
+++ b/study/src/test/resources/schema.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS users (
+                                     id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                     account VARCHAR(100) NOT NULL,
+                                     password VARCHAR(100) NOT NULL,
+                                     email VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS user_history (
+                                            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                            user_id BIGINT NOT NULL,
+                                            account VARCHAR(100) NOT NULL,
+                                            password VARCHAR(100) NOT NULL,
+                                            email VARCHAR(100) NOT NULL,
+                                            created_at DATETIME NOT NULL,
+                                            created_by VARCHAR(100) NOT NULL
+);


### PR DESCRIPTION
베로 안녕하세요! 

앞으로 더 많은 메서드가 트랜잭션을 사용해야 할 경우 계속해서 중복코드가 생기는 것도 그렇고, 서비스 클래스에 트랜잭션 관련 로직이 보여지는 것도 적합하지 않다고 생각하여 라이브러리 안에 `TransactionManager` 클래스를 만들고,  `@Runnable` 을 인자로 받아 실행하도록 하였습니다.

이 과정에서 파라미터로 connection을 계속해서 넘겨주지 않도록 ThreadLocal을 사용하였고, JDBC Template에서 try-with-resources 로 connection을 항상 close하지 않도록 변경했습니다.

대신 finally 구문을 추가해 DataSourceUtils 클래스에서 트랜잭션 밖의 connection만 close해주도록 변경하고, 트랜잭션 안의 connection은 `TransactionManager` 클래스가 직접 close 해주도록 변경했습니다.

아직은 서비스 계층에 TransactionManager 클래스를 사용하는 코드가 남아있는데, 이 부분은 4단계에서 수정하는게 좋을 것 같아 남겨두었으니 
, 이 부분을 제외하고 리뷰해주시면 좋을 것 같습니다.

또, 날씨가 많이 추워졌는데 아무래도 기습 패딩을 시도하는게 맞는 것 같아요. 얼른 패딩 가져오시죠