### PR TITLE
[JDBC 라이브러리 구현하기 - 3단계] 루카(백경환)미션 제출합니다. 

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -7,6 +7,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,11 +24,12 @@ public class UserDao {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public UserDao(final DataSource dataSource) {
-        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    public UserDao(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void insert(final User user) {
+    public void insert(final Connection connection,
+                       final User user) {
         final String sql = "insert into users (account, password, email) values (?, ?, ?)";
 
         final String account = user.getAccount();
@@ -36,10 +38,11 @@ public class UserDao {
 
         log.debug("sql={}", sql);
 
-        jdbcTemplate.update(sql, account, password, email);
+        jdbcTemplate.update(connection, sql, account, password, email);
     }
 
-    public void update(final User user) {
+    public void update(final Connection connection,
+                       final User user) {
         final String sql = "UPDATE users SET account = ?, password = ?, email = ? WHERE id = ?";
 
         final String account = user.getAccount();
@@ -49,33 +52,35 @@ public class UserDao {
 
         log.debug("sql={}", sql);
 
-        jdbcTemplate.update(sql, account, password, email, id);
+        jdbcTemplate.update(connection, sql, account, password, email, id);
     }
 
-    public List<User> findAll() {
+    public List<User> findAll(final Connection connection) {
         final String sql = "SELECT id, account, password, email FROM users";
 
         log.debug("sql={}", sql);
 
-        return jdbcTemplate.query(sql, rowMapper);
+        return jdbcTemplate.query(connection, sql, rowMapper);
     }
 
-    public User findById(final Long id) {
+    public User findById(final Connection connection,
+                         final Long id) {
         final String sql = "select id, account, password, email from users where id = ?";
 
         log.debug("sql={}", sql);
 
-        Optional<User> user = jdbcTemplate.querySingleRow(sql, rowMapper, id);
+        Optional<User> user = jdbcTemplate.querySingleRow(connection, sql, rowMapper, id);
 
         return user.orElseThrow(() -> new IllegalArgumentException("해당 아이디로 조회되는 유저가 없습니다."));
     }
 
-    public User findByAccount(final String account) {
+    public User findByAccount(final Connection connection,
+                              final String account) {
         final String sql = "select id, account, password, email from users where account = ?";
 
         log.debug("sql={}", sql);
 
-        Optional<User> user = jdbcTemplate.querySingleRow(sql, rowMapper, account);
+        Optional<User> user = jdbcTemplate.querySingleRow(connection, sql, rowMapper, account);
 
         return user.orElseThrow(() -> new IllegalArgumentException("해당 계정으로 조회되는 유로가 없습니다."));
     }

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.util.List;
 import java.util.Optional;

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-import javax.sql.DataSource;
+import java.sql.Connection;
 import java.time.LocalDateTime;
 
 public class UserHistoryDao {
@@ -14,15 +14,12 @@ public class UserHistoryDao {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public UserHistoryDao(final DataSource dataSource) {
-        this.jdbcTemplate = new JdbcTemplate(dataSource);
-    }
-
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void log(final UserHistory userHistory) {
+    public void log(final Connection connection,
+                    final UserHistory userHistory) {
         final String sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
         final long userId = userHistory.getUserId();
@@ -34,6 +31,6 @@ public class UserHistoryDao {
 
         log.debug("sql={}", sql);
 
-        jdbcTemplate.update(sql, userId, account, password, email, createdAt, createBy);
+        jdbcTemplate.update(connection, sql, userId, account, password, email, createdAt, createBy);
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,14 +1,27 @@
 package com.techcourse.service;
 
+import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import org.h2.jdbcx.JdbcDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 
 public class UserService {
 
+    private static final Logger log = LoggerFactory.getLogger(UserService.class);
+
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
+
 
     public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
         this.userDao = userDao;
@@ -16,17 +29,82 @@ public class UserService {
     }
 
     public User findById(final long id) {
-        return userDao.findById(id);
+        final DataSource dataSource = DataSourceConfig.getInstance();
+        Connection connection = initializeConnection(dataSource);
+        try {
+            User user = userDao.findById(connection, id);
+
+            commit(connection);
+            return user;
+        } catch (Exception exception) {
+            rollback(connection);
+            throw new DataAccessException(exception);
+        } finally {
+            close(connection);
+        }
     }
 
     public void insert(final User user) {
-        userDao.insert(user);
+        final DataSource dataSource = DataSourceConfig.getInstance();
+        Connection connection = initializeConnection(dataSource);
+        try {
+            userDao.insert(connection, user);
+
+            commit(connection);
+        } catch (Exception exception) {
+            rollback(connection);
+            throw new DataAccessException(exception);
+        } finally {
+            close(connection);
+        }
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+        final DataSource dataSource = DataSourceConfig.getInstance();
+        Connection connection = initializeConnection(dataSource);
+        try {
+            final var user = findById(id);
+            user.changePassword(newPassword);
+            userDao.update(connection, user);
+            userHistoryDao.log(connection, new UserHistory(user, createBy));
+
+            commit(connection);
+        } catch (Exception exception) {
+            rollback(connection);
+            throw new DataAccessException(exception);
+        } finally {
+            close(connection);
+        }
+    }
+
+    private Connection initializeConnection(final DataSource dataSource) {
+        try {
+            final Connection connection = dataSource.getConnection();
+            connection.setAutoCommit(false);
+            return connection;
+        } catch (SQLException exception) {
+            log.error(exception.getMessage(), exception);
+            throw new DataAccessException(exception);
+        }
+    }
+
+    private void commit(final Connection connection) throws SQLException {
+        connection.commit();
+    }
+
+    private void rollback(final Connection connection) {
+        try {
+            connection.rollback();
+        } catch (SQLException exception) {
+            log.error(exception.getMessage(), exception);
+        }
+    }
+
+    private void close(final Connection connection) {
+        try {
+            connection.close();
+        } catch (SQLException exception) {
+            throw new DataAccessException(exception);
+        }
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -5,106 +5,42 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
-import org.h2.jdbcx.JdbcDataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.dao.DataAccessException;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
+import org.springframework.transaction.Transaction;
 
 public class UserService {
 
-    private static final Logger log = LoggerFactory.getLogger(UserService.class);
-
     private final UserDao userDao;
+
     private final UserHistoryDao userHistoryDao;
 
+    private final Transaction transaction;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+    public UserService(final UserDao userDao,
+                       final UserHistoryDao userHistoryDao) {
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
+        this.transaction = new Transaction(DataSourceConfig.getInstance());
     }
 
     public User findById(final long id) {
-        final DataSource dataSource = DataSourceConfig.getInstance();
-        Connection connection = initializeConnection(dataSource);
-        try {
-            User user = userDao.findById(connection, id);
-
-            commit(connection);
-            return user;
-        } catch (Exception exception) {
-            rollback(connection);
-            throw new DataAccessException(exception);
-        } finally {
-            close(connection);
-        }
+        return transaction.run(connection -> userDao.findById(connection, id));
     }
 
     public void insert(final User user) {
-        final DataSource dataSource = DataSourceConfig.getInstance();
-        Connection connection = initializeConnection(dataSource);
-        try {
+        transaction.run(connection -> {
             userDao.insert(connection, user);
-
-            commit(connection);
-        } catch (Exception exception) {
-            rollback(connection);
-            throw new DataAccessException(exception);
-        } finally {
-            close(connection);
-        }
+            return null;
+        });
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final DataSource dataSource = DataSourceConfig.getInstance();
-        Connection connection = initializeConnection(dataSource);
-        try {
-            final var user = findById(id);
+        transaction.run(connection -> {
+            final User user = findById(id);
             user.changePassword(newPassword);
             userDao.update(connection, user);
             userHistoryDao.log(connection, new UserHistory(user, createBy));
 
-            commit(connection);
-        } catch (Exception exception) {
-            rollback(connection);
-            throw new DataAccessException(exception);
-        } finally {
-            close(connection);
-        }
-    }
-
-    private Connection initializeConnection(final DataSource dataSource) {
-        try {
-            final Connection connection = dataSource.getConnection();
-            connection.setAutoCommit(false);
-            return connection;
-        } catch (SQLException exception) {
-            log.error(exception.getMessage(), exception);
-            throw new DataAccessException(exception);
-        }
-    }
-
-    private void commit(final Connection connection) throws SQLException {
-        connection.commit();
-    }
-
-    private void rollback(final Connection connection) {
-        try {
-            connection.rollback();
-        } catch (SQLException exception) {
-            log.error(exception.getMessage(), exception);
-        }
-    }
-
-    private void close(final Connection connection) {
-        try {
-            connection.close();
-        } catch (SQLException exception) {
-            throw new DataAccessException(exception);
-        }
+            return null;
+        });
     }
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -5,6 +5,11 @@ import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,25 +17,30 @@ class UserDaoTest {
 
     private UserDao userDao;
 
+    private Connection connection;
+
     @BeforeEach
-    void setup() {
+    void setup() throws SQLException {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
 
-        userDao = new UserDao(DataSourceConfig.getInstance());
+        DataSource dataSource = DataSourceConfig.getInstance();
+        connection = dataSource.getConnection();
+        JdbcTemplate jdbcTemplate = new JdbcTemplate();
+        userDao = new UserDao(jdbcTemplate);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
-        userDao.insert(user);
+        userDao.insert(connection, user);
     }
 
     @Test
     void findAll() {
-        final var users = userDao.findAll();
+        final var users = userDao.findAll(connection);
 
         assertThat(users).isNotEmpty();
     }
 
     @Test
     void findById() {
-        final var user = userDao.findById(1L);
+        final var user = userDao.findById(connection, 1L);
 
         assertThat(user.getAccount()).isEqualTo("gugu");
     }
@@ -38,7 +48,7 @@ class UserDaoTest {
     @Test
     void findByAccount() {
         final var account = "gugu";
-        final var user = userDao.findByAccount(account);
+        final var user = userDao.findByAccount(connection, account);
 
         assertThat(user.getAccount()).isEqualTo(account);
     }
@@ -47,9 +57,9 @@ class UserDaoTest {
     void insert() {
         final var account = "insert-gugu";
         final var user = new User(account, "password", "hkkang@woowahan.com");
-        userDao.insert(user);
+        userDao.insert(connection, user);
 
-        final var actual = userDao.findById(2L);
+        final var actual = userDao.findById(connection, 2L);
 
         assertThat(actual.getAccount()).isEqualTo(account);
     }
@@ -57,12 +67,12 @@ class UserDaoTest {
     @Test
     void update() {
         final var newPassword = "password99";
-        final var user = userDao.findById(1L);
+        final var user = userDao.findById(connection, 1L);
         user.changePassword(newPassword);
 
-        userDao.update(user);
+        userDao.update(connection, user);
 
-        final var actual = userDao.findById(1L);
+        final var actual = userDao.findById(connection, 1L);
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -5,6 +5,9 @@ import com.techcourse.domain.UserHistory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+
 public class MockUserHistoryDao extends UserHistoryDao {
 
     public MockUserHistoryDao(final JdbcTemplate jdbcTemplate) {
@@ -12,7 +15,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void log(final UserHistory userHistory) {
+    public void log(final Connection connection, final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -13,24 +13,28 @@ import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
+
     private UserDao userDao;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws SQLException {
         DataSource dataSource = DataSourceConfig.getInstance();
-        this.jdbcTemplate = new JdbcTemplate(dataSource);
-        this.userDao = new UserDao(dataSource);
+        Connection connection = dataSource.getConnection();
+        this.jdbcTemplate = new JdbcTemplate();
+        this.userDao = new UserDao(jdbcTemplate);
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
-        userDao.insert(user);
+        userDao.insert(connection, user);
     }
 
     @Test

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -55,8 +54,6 @@ public class JdbcTemplate {
     private static class ConnectionTemplate {
 
         private final Logger log = LoggerFactory.getLogger(ConnectionTemplate.class);
-
-        public ConnectionTemplate() {}
 
         public <T> T readResult(final Connection connection,
                                 final String sql,

--- a/jdbc/src/main/java/org/springframework/jdbc/core/SelectQueryExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/SelectQueryExecutor.java
@@ -1,6 +1,5 @@
 package org.springframework.jdbc.core;
 
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 

--- a/jdbc/src/main/java/org/springframework/transaction/Transaction.java
+++ b/jdbc/src/main/java/org/springframework/transaction/Transaction.java
@@ -1,0 +1,67 @@
+package org.springframework.transaction;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class Transaction {
+
+    private static final Logger log = LoggerFactory.getLogger(Transaction.class);
+
+    private final DataSource dataSource;
+
+    public Transaction(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public <T> T run(final TransactionTemplate<T> transactionTemplate) {
+        final Connection connection = initializeConnection();
+        try {
+            final T result = transactionTemplate.execute(connection);
+
+            commit(connection);
+
+            return result;
+        } catch (Exception exception) {
+            rollback(connection);
+            throw new DataAccessException(exception);
+        } finally {
+            close(connection);
+        }
+    }
+
+    private Connection initializeConnection() {
+        try {
+            final Connection connection = dataSource.getConnection();
+            connection.setAutoCommit(false);
+            return connection;
+        } catch (SQLException exception) {
+            log.error(exception.getMessage(), exception);
+            throw new DataAccessException(exception);
+        }
+    }
+
+    private void commit(final Connection connection) throws SQLException {
+        connection.commit();
+    }
+
+    private void rollback(final Connection connection) {
+        try {
+            connection.rollback();
+        } catch (SQLException exception) {
+            log.error(exception.getMessage(), exception);
+        }
+    }
+
+    private void close(final Connection connection) {
+        try {
+            connection.close();
+        } catch (SQLException exception) {
+            throw new DataAccessException(exception);
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/transaction/TransactionTemplate.java
+++ b/jdbc/src/main/java/org/springframework/transaction/TransactionTemplate.java
@@ -1,0 +1,9 @@
+package org.springframework.transaction;
+
+import java.sql.Connection;
+
+@FunctionalInterface
+public interface TransactionTemplate<T> {
+
+    T execute(final Connection connection);
+}


### PR DESCRIPTION
안녕하세요! 필립!

이번 3단계에서는
서비스 로직들을 하나의 트랜잭션 단위로 묶으라는 것이 포인트였는데요.
그렇다보니, 제가 실제 쿼리문을 execute하는 곳인 QueryExecutor까지  Connection을 넘겨주게 되었습니다.
`유저 서비스` &rarr; `유저 DAO, 유저 히스토리 DAO` &rarr; `JdbcTemplate` &rarr; `ConnectionTemplate` &rarr; `QueryExecutor` 
이 부분 때문에JdbcTemplate을 사용하면서 개발하는 개발자가  서비스를 개발하면서 너무 불편함이 있을 것 같았습니다. 그래서 리팩토링이 매우 하고 싶었지만, 일단 다음 단계로 미뤘습니다!!
이번엔 어떻게 유저가 트랜잭션을 잘 쓸 수 있을지만 고려해서 작성해보았습니다!!
아직 부족한 점이 많지만 다음단계에서 리팩토링 제대로 해보겠습니다!!