### PR TITLE
[JDBC 라이브러리 구현하기 - 2, 3단계] 모디(전제희) 미션 제출합니다.

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -6,57 +6,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 
 public class UserHistoryDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
-    private final DataSource dataSource;
+
+    private final JdbcTemplate jdbcTemplate;
 
     public UserHistoryDao(final DataSource dataSource) {
-        this.dataSource = dataSource;
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
-        this.dataSource = null;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void log(final UserHistory userHistory) {
-        final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
-
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
-
-            log.debug("query : {}", sql);
-
-            pstmt.setLong(1, userHistory.getUserId());
-            pstmt.setString(2, userHistory.getAccount());
-            pstmt.setString(3, userHistory.getPassword());
-            pstmt.setString(4, userHistory.getEmail());
-            pstmt.setObject(5, userHistory.getCreatedAt());
-            pstmt.setString(6, userHistory.getCreateBy());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+    public void log(UserHistory userHistory) {
+        String sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.update(sql, userHistory.getUserId(), userHistory.getAccount(), userHistory.getPassword(), userHistory.getEmail(), userHistory.getCreatedAt(), userHistory.getCreateBy());
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,12 +1,21 @@
 package com.techcourse.service;
 
+import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 public class UserService {
 
+    private static final Logger log = LoggerFactory.getLogger(UserService.class);
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
 
@@ -24,9 +33,29 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+        DataSource dataSource = DataSourceConfig.getInstance();
+        Connection conn = null;
+        try {
+            conn = dataSource.getConnection();
+            conn.setAutoCommit(false);
+            TransactionSynchronizationManager.bindResource(dataSource, conn);
+            User user = findById(id);
+            user.changePassword(newPassword);
+            userDao.update(user);
+            userHistoryDao.log(new UserHistory(user, createBy));
+            conn.commit();
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            if (conn != null) {
+                try {
+                    TransactionSynchronizationManager.unbindResource(dataSource);
+                    conn.rollback();
+                    conn.close();
+                } catch (SQLException ex) {
+                    log.error(ex.getMessage(), ex);
+                }
+            }
+            throw new DataAccessException();
+        }
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -8,13 +8,11 @@ import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;

--- a/jdbc/src/main/java/org/springframework/jdbc/ColumnConversionException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/ColumnConversionException.java
@@ -1,0 +1,7 @@
+package org.springframework.jdbc;
+
+import org.springframework.dao.DataAccessException;
+
+public class ColumnConversionException extends DataAccessException {
+
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/IncorrectResultSizeDataAccessException.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/IncorrectResultSizeDataAccessException.java
@@ -1,5 +1,7 @@
 package org.springframework.jdbc;
 
-public class IncorrectResultSizeDataAccessException extends RuntimeException {
+import org.springframework.dao.DataAccessException;
+
+public class IncorrectResultSizeDataAccessException extends DataAccessException {
 
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ColumnTypes.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ColumnTypes.java
@@ -1,5 +1,7 @@
 package org.springframework.jdbc.core;
 
+import org.springframework.jdbc.ColumnConversionException;
+
 public class ColumnTypes {
 
     /**
@@ -14,7 +16,7 @@ public class ColumnTypes {
             case 12:
                 return String.class;
             default:
-                throw new IllegalStateException();
+                throw new ColumnConversionException();
         }
     }
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/InstantiateUtil.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/InstantiateUtil.java
@@ -1,0 +1,22 @@
+package org.springframework.jdbc.core;
+
+import java.lang.reflect.Constructor;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+
+public class InstantiateUtil {
+
+    public static <T> T instantiate(ResultSet rs, Class<T> requiredType, Object[] initArgs)
+            throws Exception {
+        ResultSetMetaData metaData = rs.getMetaData();
+        int columnCount = metaData.getColumnCount();
+
+        Class<?>[] columnTypes = new Class[columnCount];
+        for (int i = 1; i <= columnCount; i++) {
+            int columnType = metaData.getColumnType(i);
+            columnTypes[i - 1] = ColumnTypes.convertToClass(columnType);
+        }
+        Constructor<?> constructor = requiredType.getDeclaredConstructor(columnTypes);
+        return requiredType.cast(constructor.newInstance(initArgs));
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/StatementExecution.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/StatementExecution.java
@@ -1,0 +1,8 @@
+package org.springframework.jdbc.core;
+
+@FunctionalInterface
+public interface StatementExecution<T, R> {
+
+    R apply(T t) throws Exception;
+
+}

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
@@ -1,23 +1,31 @@
 package org.springframework.transaction.support;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.sql.DataSource;
 
-public abstract class TransactionSynchronizationManager {
+public class TransactionSynchronizationManager {
 
-    private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
+    private static final ThreadLocal<Map<DataSource, Connection>> resources;
 
-    private TransactionSynchronizationManager() {}
+    static {
+        resources = new ThreadLocal<>();
+        resources.set(new ConcurrentHashMap<>());
+    }
+
+    private TransactionSynchronizationManager() {
+    }
 
     public static Connection getResource(DataSource key) {
-        return null;
+        return resources.get().get(key);
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        resources.get().put(key, value);
     }
 
     public static Connection unbindResource(DataSource key) {
-        return null;
+        return resources.get().remove(key);
     }
 }


### PR DESCRIPTION
콩하나 안녕하세요~
정말 오래 빈둥대다가.. 이제야 몰아서 미션 했습니다...ㅎㅎ;;

1단계에서 주신 질문에 대한 답변은 모두 달아두었습니다.
2단계 내용의 주요한 점은 connection 획득 및 statement 생성을 한 곳으로 몰았다는 점이고요,
3단계는 service에서 connection을 생성해서 시그니처를 하나하나 바꿔서 넣어주다가...
불편을 참지 못해 4단계에서 쓸 TransactionSynchronizationManager를 통해 ThreadLocal에서 connection을 꺼내 쓰게 해버렸습니다..

changePassword 메서드에 대해서만 TransactionSynchronizationManager를 사용하게 하여
어떠한 서비스 로직은 내부적으로 connection을 생성하고 changePassword는 외부에서 생성한 connection을 공유하는 상황입니다

이로 인해 JdbcTemplate의 connection 획득 방법이 경우에 따라 달라지게 되었는데요,
JdbcTemplate은 외부에서 connection을 생성했는지, 아니면 자신이 생성해야 하는지 (or 트랜잭션이 외부에서 관리되는지)알 수 없으므로 이러한 방향이 3단계에선 조금 더 맞지 않을까.. 싶어서 이렇게 하게 되었어요

try ~ catch를 바르게 적용했는지 잘 모르겠네요 😂
4단계를 하면 트랜잭션으로 인한 지저분한 부분들을 많이 개선할 수 있을 것 같고요.
꼼꼼한 리뷰 감사합니다~!!