### PR TITLE
[JDBC 라이브러리 구현하기 - 3단계] 바론(이소민) 미션 제출합니다. 

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -2,6 +2,7 @@ package com.techcourse.dao;
 
 import com.techcourse.dao.exception.UserNotExistException;
 import com.techcourse.domain.User;
+import java.sql.Connection;
 import java.util.List;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -33,6 +34,12 @@ public class UserDao {
         final String sql = "update users set account = ?, password = ?, email = ? where id = ?";
 
         jdbcTemplate.update(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
+    }
+
+    public void update(final Connection con, final User user) {
+        final String sql = "update users set account = ?, password = ?, email = ? where id = ?";
+
+        jdbcTemplate.update(con, sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
     }
 
     public List<User> findAll() {

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,62 +1,44 @@
 package com.techcourse.dao;
 
 import com.techcourse.domain.UserHistory;
-import org.springframework.jdbc.core.JdbcTemplate;
+import java.sql.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 public class UserHistoryDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
-    private final DataSource dataSource;
-
-    public UserHistoryDao(final DataSource dataSource) {
-        this.dataSource = dataSource;
-    }
+    private final JdbcTemplate jdbcTemplate;
 
     public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
-        this.dataSource = null;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        try {
-            conn = dataSource.getConnection();
-            pstmt = conn.prepareStatement(sql);
+        jdbcTemplate.update(sql,
+            userHistory.getUserId(),
+            userHistory.getAccount(),
+            userHistory.getPassword(),
+            userHistory.getEmail(),
+            userHistory.getCreatedAt(),
+            userHistory.getCreateBy()
+        );
+    }
 
-            log.debug("query : {}", sql);
+    public void log(final Connection con, final UserHistory userHistory) {
+        final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
-            pstmt.setLong(1, userHistory.getUserId());
-            pstmt.setString(2, userHistory.getAccount());
-            pstmt.setString(3, userHistory.getPassword());
-            pstmt.setString(4, userHistory.getEmail());
-            pstmt.setObject(5, userHistory.getCreatedAt());
-            pstmt.setString(6, userHistory.getCreateBy());
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            log.error(e.getMessage(), e);
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                if (pstmt != null) {
-                    pstmt.close();
-                }
-            } catch (SQLException ignored) {}
-
-            try {
-                if (conn != null) {
-                    conn.close();
-                }
-            } catch (SQLException ignored) {}
-        }
+        jdbcTemplate.update(con, sql,
+            userHistory.getUserId(),
+            userHistory.getAccount(),
+            userHistory.getPassword(),
+            userHistory.getEmail(),
+            userHistory.getCreatedAt(),
+            userHistory.getCreateBy()
+        );
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -4,15 +4,21 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.springframework.dao.DataAccessException;
 
 public class UserService {
 
     private final UserDao userDao;
     private final UserHistoryDao userHistoryDao;
+    private final DataSource dataSource;
 
-    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+    public UserService(final UserDao userDao, final UserHistoryDao userHistoryDao, final DataSource dataSource) {
         this.userDao = userDao;
         this.userHistoryDao = userHistoryDao;
+        this.dataSource = dataSource;
     }
 
     public User findById(final long id) {
@@ -24,9 +30,40 @@ public class UserService {
     }
 
     public void changePassword(final long id, final String newPassword, final String createBy) {
+        Connection connection = null;
+        // 하나의 Connection 을 공유하도록 해야한다.
+        try {
+            // TODO: 2023-10-05 Connection 을 가져오고, commit/rollback, close 하는 부분 로직 중복 처리
+            connection = dataSource.getConnection();
+            connection.setAutoCommit(false);
+            // 아래 라인에서 실제 실행할 로직만 두는 것
+            executeChangePassword(id, newPassword, createBy, connection);
+            connection.commit();
+        } catch (Exception e) {
+            if (connection != null) {
+                try {
+                    connection.rollback();
+                } catch (SQLException ex) {
+                    throw new DataAccessException(ex);
+                }
+            }
+            throw new DataAccessException();
+        } finally {
+            if (connection != null) {
+                try {
+                    connection.close();
+                } catch (SQLException e) {
+                    throw new DataAccessException(e);
+                }
+            }
+        }
+    }
+
+    private void executeChangePassword(final long id, final String newPassword, final String createBy, final Connection connection) {
         final var user = findById(id);
         user.changePassword(newPassword);
-        userDao.update(user);
-        userHistoryDao.log(new UserHistory(user, createBy));
+        // TODO: 2023-10-05 DAO가 Connection을 몰라도 되도록 수정하기
+        userDao.update(connection, user);
+        userHistoryDao.log(connection, new UserHistory(user, createBy));
     }
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -8,24 +8,27 @@ import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.ConnectionManager;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 class UserDaoTest {
 
     private UserDao userDao;
+    private ConnectionManager connectionManager;
 
     @BeforeEach
     void setup() {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+        connectionManager = new ConnectionManager(DataSourceConfig.getInstance());
 
-        userDao = new UserDao(new JdbcTemplate(DataSourceConfig.getInstance()));
+        userDao = new UserDao(new JdbcTemplate(connectionManager));
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }
 
     @AfterEach
     void tearDown() {
-        final JdbcTemplate jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        final JdbcTemplate jdbcTemplate = new JdbcTemplate(connectionManager);
         jdbcTemplate.update("TRUNCATE TABLE `users` RESTART IDENTITY");
     }
 

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,9 @@ class UserDaoTest {
 
     @BeforeEach
     void setup() {
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
-        connectionManager = new ConnectionManager(DataSourceConfig.getInstance());
+        final DataSource dataSource = DataSourceConfig.getInstance();
+        DatabasePopulatorUtils.execute(dataSource);
+        connectionManager = new ConnectionManager(dataSource);
 
         userDao = new UserDao(new JdbcTemplate(connectionManager));
         final var user = new User("gugu", "password", "hkkang@woowahan.com");

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -9,28 +9,26 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.jdbc.core.ConnectionManager;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 class UserDaoTest {
 
     private UserDao userDao;
-    private ConnectionManager connectionManager;
+    private DataSource dataSource;
 
     @BeforeEach
     void setup() {
-        final DataSource dataSource = DataSourceConfig.getInstance();
+        dataSource = DataSourceConfig.getInstance();
         DatabasePopulatorUtils.execute(dataSource);
-        connectionManager = new ConnectionManager(dataSource);
 
-        userDao = new UserDao(new JdbcTemplate(connectionManager));
+        userDao = new UserDao(new JdbcTemplate(dataSource));
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }
 
     @AfterEach
     void tearDown() {
-        final JdbcTemplate jdbcTemplate = new JdbcTemplate(connectionManager);
+        final JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
         jdbcTemplate.update("TRUNCATE TABLE `users` RESTART IDENTITY");
     }
 

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -2,6 +2,7 @@ package com.techcourse.service;
 
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
+import java.sql.Connection;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -13,6 +14,12 @@ public class MockUserHistoryDao extends UserHistoryDao {
 
     @Override
     public void log(final UserHistory userHistory) {
+        throw new DataAccessException();
+    }
+
+    // TODO: 2023-10-05 임의로 추가한 아래 메서드 사용안해도 테스트 통과하게 수정 -> 즉 Connection 파라미터 받지 않도록
+    @Override
+    public void log(final Connection con, final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -12,16 +12,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionExecutor;
 
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
+    private TransactionExecutor transactionExecutor;
 
     @BeforeEach
     void setUp() {
         this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
         this.userDao = new UserDao(jdbcTemplate);
+        this.transactionExecutor = new TransactionExecutor(DataSourceConfig.getInstance());
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
@@ -31,7 +34,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao, DataSourceConfig.getInstance());
+        final var userService = new UserService(userDao, userHistoryDao, transactionExecutor);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -46,7 +49,7 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao, DataSourceConfig.getInstance());
+        final var userService = new UserService(userDao, userHistoryDao, transactionExecutor);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -1,20 +1,18 @@
 package com.techcourse.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-@Disabled
 class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
@@ -33,7 +31,7 @@ class UserServiceTest {
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, DataSourceConfig.getInstance());
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -48,13 +46,14 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(userDao, userHistoryDao);
+        final var userService = new UserService(userDao, userHistoryDao, DataSourceConfig.getInstance());
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";
         // 트랜잭션이 정상 동작하는지 확인하기 위해 의도적으로 MockUserHistoryDao에서 예외를 발생시킨다.
+
         assertThrows(DataAccessException.class,
-                () -> userService.changePassword(1L, newPassword, createBy));
+            () -> userService.changePassword(1L, newPassword, createBy));
 
         final var actual = userService.findById(1L);
 

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ConnectionManager;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.support.TransactionExecutor;
 
@@ -22,9 +23,10 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        this.jdbcTemplate = new JdbcTemplate(DataSourceConfig.getInstance());
+        final ConnectionManager connectionManager = new ConnectionManager(DataSourceConfig.getInstance());
+        this.jdbcTemplate = new JdbcTemplate(connectionManager);
         this.userDao = new UserDao(jdbcTemplate);
-        this.transactionExecutor = new TransactionExecutor(DataSourceConfig.getInstance());
+        this.transactionExecutor = new TransactionExecutor(connectionManager);
 
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -8,10 +8,10 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
-import org.springframework.jdbc.core.ConnectionManager;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.support.TransactionExecutor;
 
@@ -23,12 +23,12 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        final ConnectionManager connectionManager = new ConnectionManager(DataSourceConfig.getInstance());
-        this.jdbcTemplate = new JdbcTemplate(connectionManager);
+        final DataSource dataSource = DataSourceConfig.getInstance();
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
         this.userDao = new UserDao(jdbcTemplate);
-        this.transactionExecutor = new TransactionExecutor(connectionManager);
+        this.transactionExecutor = new TransactionExecutor(dataSource);
 
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+        DatabasePopulatorUtils.execute(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionManager.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionManager.java
@@ -1,0 +1,35 @@
+package org.springframework.jdbc.core;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.springframework.dao.DataAccessException;
+
+public class ConnectionManager {
+
+    private final DataSource dataSource;
+
+    public ConnectionManager(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public Connection getConnection() {
+        try {
+            return dataSource.getConnection();
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
+    }
+
+    public void closeConnection(final Connection connection) {
+        if (connection == null) {
+            return;
+        }
+
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionManager.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/ConnectionManager.java
@@ -7,13 +7,10 @@ import org.springframework.dao.DataAccessException;
 
 public class ConnectionManager {
 
-    private final DataSource dataSource;
-
-    public ConnectionManager(final DataSource dataSource) {
-        this.dataSource = dataSource;
+    private ConnectionManager() {
     }
 
-    public Connection getConnection() {
+    public static Connection getConnection(final DataSource dataSource) {
         try {
             return dataSource.getConnection();
         } catch (SQLException e) {
@@ -21,7 +18,7 @@ public class ConnectionManager {
         }
     }
 
-    public void closeConnection(final Connection connection) {
+    public static void closeConnection(final Connection connection) {
         if (connection == null) {
             return;
         }

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -49,6 +49,7 @@ public class JdbcTemplate {
         }, args);
     }
 
+    // TODO: 2023-10-07 Connection 생성, 삭제 관리하는 클래스 만들기 => 단, 이번에는 단순히 중복 로직 제거를 위함이므로 ThreadLocal이나 Connection 을 하나로 유지하는 건 고려하지 않음
     private <T> T executeInternal(final String sql, final QueryExecutor<T> executor, final Object... args) {
         Connection con = null;
         try {

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -6,6 +6,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
@@ -16,10 +17,10 @@ public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
 
-    private final ConnectionManager connectionManager;
+    private final DataSource dataSource;
 
-    public JdbcTemplate(final ConnectionManager connectionManager) {
-        this.connectionManager = connectionManager;
+    public JdbcTemplate(final DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper, final Object... args) {
@@ -49,11 +50,11 @@ public class JdbcTemplate {
     }
 
     private <T> T executeInternal(final String sql, final QueryExecutor<T> executor, final Object... args) {
-        final Connection connection = connectionManager.getConnection();
+        final Connection connection = ConnectionManager.getConnection(dataSource);
         try {
             return executeInternalWithConnection(connection, sql, executor, args);
         } finally {
-            connectionManager.closeConnection(connection);
+            ConnectionManager.closeConnection(connection);
         }
     }
 

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionExecutor.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionExecutor.java
@@ -1,0 +1,56 @@
+package org.springframework.transaction.support;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.springframework.dao.DataAccessException;
+
+public class TransactionExecutor {
+
+    private final DataSource dataSource;
+
+    public TransactionExecutor(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void execute(final TransactionWorker worker) {
+        Connection connection = null;
+        try {
+            connection = dataSource.getConnection();
+            connection.setAutoCommit(false);
+
+            worker.run(connection);
+
+            connection.commit();
+        } catch (Exception e) {
+            rollback(connection);
+            throw new DataAccessException();
+        } finally {
+            closeConnection(connection);
+        }
+    }
+
+    private void rollback(final Connection connection) {
+        if (connection == null) {
+            return;
+        }
+
+        try {
+            connection.rollback();
+        } catch (SQLException ex) {
+            throw new DataAccessException(ex);
+        }
+    }
+
+    private void closeConnection(final Connection connection) {
+        if (connection == null) {
+            return;
+        }
+
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            throw new DataAccessException(e);
+        }
+    }
+}

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionExecutor.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionExecutor.java
@@ -2,19 +2,20 @@ package org.springframework.transaction.support;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import javax.sql.DataSource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.ConnectionManager;
 
 public class TransactionExecutor {
 
-    private final ConnectionManager connectionManager;
+    private final DataSource dataSource;
 
-    public TransactionExecutor(final ConnectionManager connectionManager) {
-        this.connectionManager = connectionManager;
+    public TransactionExecutor(final DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
     public void execute(final TransactionWorker worker) {
-        final Connection connection = connectionManager.getConnection();
+        final Connection connection = ConnectionManager.getConnection(dataSource);
         try {
             connection.setAutoCommit(false);
 
@@ -25,7 +26,7 @@ public class TransactionExecutor {
             rollback(connection);
             throw new DataAccessException(e);
         } finally {
-            connectionManager.closeConnection(connection);
+            ConnectionManager.closeConnection(connection);
         }
     }
 

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionWorker.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionWorker.java
@@ -1,0 +1,9 @@
+package org.springframework.transaction.support;
+
+import java.sql.Connection;
+
+@FunctionalInterface
+public interface TransactionWorker {
+
+    void run(final Connection connection);
+}

--- a/study/build.gradle
+++ b/study/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
     implementation "org.reflections:reflections:0.10.2"
     implementation "ch.qos.logback:logback-classic:1.2.12"
+    implementation "ch.qos.logback:logback-core:1.2.12" // mysql.start() 시에 logback NoSuchMethodFoundException 해결 위해 추가
     implementation "org.apache.commons:commons-lang3:3.13.0"
 
     testImplementation "org.springframework.boot:spring-boot-starter-test:2.7.14"

--- a/study/src/test/java/transaction/stage2/FirstUserService.java
+++ b/study/src/test/java/transaction/stage2/FirstUserService.java
@@ -66,7 +66,7 @@ public class FirstUserService {
         throw new RuntimeException();
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithSupports() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -77,7 +77,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithMandatory() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -88,7 +88,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNotSupported() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -99,7 +99,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNested() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -110,7 +110,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNever() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());


### PR DESCRIPTION
안녕하세요 이레~~~ 바론입니다 🙇‍♀️ 

이번에는 3단계 요구사항에 맞춰서 `UserService`의 `changePassword` 내의 로직들이 모두 같은 트랜잭션 내에서 실행되도록 구현했습니다! 여기에서 트랜잭션 작업을 처리해주는 `TransactionExecutor` 클래스가 추가되었습니다.

그리고 기존에 있던 `dao`, `jdbcTemplate` 의 코드를 모두 외부에서 `Connection`을 파라미터로 받아오는 코드로 바꾸는 것 보다, 기존에 있던 코드에 `Connection`을 받는 상황도 처리할 수 있도록 확장하여 기존 코드의 변경을 가급적 줄이기 위해서 메서드 오버로딩으로 Connection 을 받아오는 `update` 메서드를 추가했습니다.

그리고 Connection을 생성하고, close 해주는 로직을 담당하는 `ConnectionManager`를 추가했습니다!

현재 코드에 TODO로 남아있거나, 리팩터링이 덜 된 부분들 중 4단계 요구사항이라고 생각하여 반영하지 않은 부분은 다음과 같습니다.
1. `Dao`가 `Connection` 을 파라미터로 받아오는 것
2. 스레드 별로 `Connection`을 분리하는 것

이 부분들은 4단계 리팩터링 시에 적용하려 합니다.

이번 리뷰도 잘 부탁드립니다! 감사합니다 :)