### PR TITLE
[JDBC 라이브러리 구현하기 - 4단계] 콩하나(최한빈) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@
 - [x] 트랜잭션 경계 설정을 할 수 있다.
   - [x] 서비스에서 커넥션을 가져온다.
   - [x] dao의 메소드를 호출할 때 커넥션을 전달한다.
+
+## 4.Transaction synchronization 적용하기
+- [ ] Transaction synchronization 적용
+  - [ ] DataSourceUtils를 사용해 connection 객체를 가져온다.
+  - [ ] TransactionSynchronizationManager가 잘 동작하도록 구현한다.
+- [ ] 트랜잭션 서비스 추상화
+  - [ ] 비즈니스 로직과 데이터 액세스 로직 분리

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@
 ## 4.Transaction synchronization 적용하기
 - [ ] Transaction synchronization 적용
   - [ ] DataSourceUtils를 사용해 connection 객체를 가져온다.
-  - [ ] TransactionSynchronizationManager가 잘 동작하도록 구현한다.
+  - [x] TransactionSynchronizationManager가 잘 동작하도록 구현한다.
 - [ ] 트랜잭션 서비스 추상화
   - [ ] 비즈니스 로직과 데이터 액세스 로직 분리

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
   - [x] dao의 메소드를 호출할 때 커넥션을 전달한다.
 
 ## 4.Transaction synchronization 적용하기
-- [ ] Transaction synchronization 적용
-  - [ ] DataSourceUtils를 사용해 connection 객체를 가져온다.
+- [x] Transaction synchronization 적용
+  - [x] DataSourceUtils를 사용해 connection 객체를 가져온다.
   - [x] TransactionSynchronizationManager가 잘 동작하도록 구현한다.
 - [ ] 트랜잭션 서비스 추상화
   - [ ] 비즈니스 로직과 데이터 액세스 로직 분리

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@
 - [x] Transaction synchronization 적용
   - [x] DataSourceUtils를 사용해 connection 객체를 가져온다.
   - [x] TransactionSynchronizationManager가 잘 동작하도록 구현한다.
-- [ ] 트랜잭션 서비스 추상화
-  - [ ] 비즈니스 로직과 데이터 액세스 로직 분리
+- [x] 트랜잭션 서비스 추상화
+  - [x] 비즈니스 로직과 데이터 액세스 로직 분리

--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -22,34 +22,32 @@ public class UserDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void insert(final Connection connection, final User user) {
+    public void insert(final User user) {
         final var sql = "insert into users (account, password, email) values (?, ?, ?)";
 
-        jdbcTemplate.execute(connection, sql, user.getAccount(), user.getPassword(), user.getEmail());
+        jdbcTemplate.execute(sql, user.getAccount(), user.getPassword(), user.getEmail());
     }
 
-    public void update(final Connection connection, final User user) {
+    public void update(final User user) {
         final var sql = "update users set (account, password, email) = (?, ?, ?) where id = ?";
 
-        jdbcTemplate.execute(connection, sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
+        jdbcTemplate.execute(sql, user.getAccount(), user.getPassword(), user.getEmail(), user.getId());
     }
 
-    public List<User> findAll(final Connection connection) {
+    public List<User> findAll() {
         final var sql = "select id, account, password, email from users";
 
-        return jdbcTemplate.findAll(connection,
-                sql,
+        return jdbcTemplate.findAll(sql,
                 rs -> new User(rs.getLong("id"),
                         rs.getString("account"),
                         rs.getString("password"),
                         rs.getString("email")));
     }
 
-    public User findById(final Connection connection, final Long id) {
+    public User findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
 
-        return jdbcTemplate.find(connection,
-                sql,
+        return jdbcTemplate.find(sql,
                 rs -> new User(rs.getLong("id"),
                         rs.getString("account"),
                         rs.getString("password"),
@@ -57,11 +55,10 @@ public class UserDao {
                 id);
     }
 
-    public User findByAccount(final Connection connection, final String account) {
+    public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
 
-        return jdbcTemplate.find(connection,
-                sql,
+        return jdbcTemplate.find(sql,
                 rs -> new User(rs.getLong("id"),
                         rs.getString("account"),
                         rs.getString("password"),

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -21,10 +21,10 @@ public class UserHistoryDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    public void log(final Connection connection, final UserHistory userHistory) {
+    public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
 
-        jdbcTemplate.execute(connection, sql, userHistory.getUserId(), userHistory.getAccount(),
+        jdbcTemplate.execute(sql, userHistory.getUserId(), userHistory.getAccount(),
                 userHistory.getPassword(), userHistory.getEmail(), userHistory.getCreatedAt(), userHistory.getCreateBy());
     }
 }

--- a/app/src/main/java/com/techcourse/service/AppUserService.java
+++ b/app/src/main/java/com/techcourse/service/AppUserService.java
@@ -1,0 +1,32 @@
+package com.techcourse.service;
+
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+
+public class AppUserService implements UserService {
+
+    private final UserDao userDao;
+    private final UserHistoryDao userHistoryDao;
+
+    public AppUserService(final UserDao userDao, final UserHistoryDao userHistoryDao) {
+        this.userDao = userDao;
+        this.userHistoryDao = userHistoryDao;
+    }
+
+    public User findById(final long id) {
+        return userDao.findById(id);
+    }
+
+    public void insert(final User user) {
+        userDao.insert(user);
+    }
+
+    public void changePassword(final long id, final String newPassword, final String createBy) {
+        final var user = findById(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createBy));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TransactionalDaoExecutor.java
+++ b/app/src/main/java/com/techcourse/service/TransactionalDaoExecutor.java
@@ -1,9 +1,7 @@
 package com.techcourse.service;
 
-import java.sql.Connection;
-
 @FunctionalInterface
 public interface TransactionalDaoExecutor<T> {
 
-    T execute(final Connection connection);
+    T execute();
 }

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,0 +1,62 @@
+package com.techcourse.service;
+
+import com.techcourse.domain.User;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.JdbcTemplateException;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+
+public class TxUserService implements UserService {
+
+    private final UserService userService;
+    private final DataSource dataSource;
+
+    public TxUserService(UserService userService, DataSource dataSource) {
+        this.userService = userService;
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public User findById(long id) {
+        return doService(() -> userService.findById(id));
+    }
+
+    private <T> T doService(final TransactionalDaoExecutor<T> executor) {
+        try {
+            return doDaoWithTransaction(executor);
+        } catch (SQLException e) {
+            throw new DataBaseAccessException(e.getMessage());
+        }
+    }
+
+    private <T> T doDaoWithTransaction(final TransactionalDaoExecutor<T> executor) throws SQLException {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
+        connection.setAutoCommit(false);
+        try {
+            return executor.execute();
+        } catch (JdbcTemplateException e) {
+            connection.rollback();
+            throw new DataBaseAccessException(e.getMessage());
+        } finally {
+            connection.setAutoCommit(true);
+            DataSourceUtils.releaseConnection(connection, dataSource);
+        }
+    }
+
+    @Override
+    public void insert(User user) {
+        doService(() -> {
+            userService.insert(user);
+            return null;
+        });
+    }
+
+    @Override
+    public void changePassword(long id, String newPassword, String createBy) {
+        doService(() -> {
+            userService.changePassword(id, newPassword, createBy);
+            return null;
+        });
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -12,13 +12,13 @@ public class TxUserService implements UserService {
     private final UserService userService;
     private final DataSource dataSource;
 
-    public TxUserService(UserService userService, DataSource dataSource) {
+    public TxUserService(final UserService userService, final DataSource dataSource) {
         this.userService = userService;
         this.dataSource = dataSource;
     }
 
     @Override
-    public User findById(long id) {
+    public User findById(final long id) {
         return doService(() -> userService.findById(id));
     }
 
@@ -45,7 +45,7 @@ public class TxUserService implements UserService {
     }
 
     @Override
-    public void insert(User user) {
+    public void insert(final User user) {
         doService(() -> {
             userService.insert(user);
             return null;
@@ -53,7 +53,7 @@ public class TxUserService implements UserService {
     }
 
     @Override
-    public void changePassword(long id, String newPassword, String createBy) {
+    public void changePassword(final long id, final String newPassword, final String createBy) {
         doService(() -> {
             userService.changePassword(id, newPassword, createBy);
             return null;

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,69 +1,12 @@
 package com.techcourse.service;
 
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
-import java.sql.SQLException;
-import javax.sql.DataSource;
-import org.springframework.jdbc.core.JdbcTemplateException;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 
-public class UserService {
+public interface UserService {
 
-    private final DataSource dataSource;
-    private final UserDao userDao;
-    private final UserHistoryDao userHistoryDao;
+    User findById(final long id);
 
-    public UserService(final DataSource dataSource, final UserDao userDao, final UserHistoryDao userHistoryDao) {
-        this.dataSource = dataSource;
-        this.userDao = userDao;
-        this.userHistoryDao = userHistoryDao;
-    }
+    void insert(final User user);
 
-    public User findById(final long id) {
-        return doService(connection -> userDao.findById(connection, id));
-    }
-
-    private <T> T doService(final TransactionalDaoExecutor<T> executor) {
-        try {
-            Connection connection = DataSourceUtils.getConnection(dataSource);
-            return doDaoWithTransaction(executor, connection);
-        } catch (SQLException e) {
-            throw new DataBaseAccessException(e.getMessage());
-        }
-    }
-
-    private <T> T doDaoWithTransaction(final TransactionalDaoExecutor<T> executor,
-                                       final Connection connection) throws SQLException {
-        connection.setAutoCommit(false);
-        try {
-            return executor.execute(connection);
-        } catch (JdbcTemplateException e) {
-            connection.rollback();
-            throw new DataBaseAccessException(e.getMessage());
-        } finally {
-            connection.setAutoCommit(true);
-            DataSourceUtils.releaseConnection(connection, dataSource);
-        }
-    }
-
-    public void insert(final User user) {
-        doService(connection -> {
-            userDao.insert(connection, user);
-            return null;
-        });
-    }
-
-    public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-
-        doService(connection -> {
-            userDao.update(connection, user);
-            userHistoryDao.log(connection, new UserHistory(user, createBy));
-            return null;
-        });
-    }
+    void changePassword(final long id, final String newPassword, final String createBy);
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -8,6 +8,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplateException;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 
 public class UserService {
 
@@ -27,7 +28,7 @@ public class UserService {
 
     private <T> T doService(final TransactionalDaoExecutor<T> executor) {
         try {
-            Connection connection = dataSource.getConnection();
+            Connection connection = DataSourceUtils.getConnection(dataSource);
             return doDaoWithTransaction(executor, connection);
         } catch (SQLException e) {
             throw new DataBaseAccessException(e.getMessage());
@@ -44,6 +45,7 @@ public class UserService {
             throw new DataBaseAccessException(e.getMessage());
         } finally {
             connection.setAutoCommit(true);
+            DataSourceUtils.releaseConnection(connection, dataSource);
         }
     }
 

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -27,7 +27,7 @@ class UserDaoTest {
         connection = dataSource.getConnection();
         userDao = new UserDao(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
-        userDao.insert(connection, user);
+        userDao.insert(user);
     }
 
     @AfterEach
@@ -39,14 +39,14 @@ class UserDaoTest {
 
     @Test
     void findAll() throws SQLException {
-        final var users = userDao.findAll(connection);
+        final var users = userDao.findAll();
 
         assertThat(users).isNotEmpty();
     }
 
     @Test
     void findById() {
-        final var user = userDao.findById(connection, 1L);
+        final var user = userDao.findById(1L);
 
         assertThat(user.getAccount()).isEqualTo("gugu");
     }
@@ -54,7 +54,7 @@ class UserDaoTest {
     @Test
     void findByAccount() {
         final var account = "gugu";
-        final var user = userDao.findByAccount(connection, account);
+        final var user = userDao.findByAccount(account);
 
         assertThat(user.getAccount()).isEqualTo(account);
     }
@@ -63,22 +63,21 @@ class UserDaoTest {
     void insert() {
         final var account = "insert-gugu";
         final var user = new User(account, "password", "hkkang@woowahan.com");
-        userDao.insert(connection, user);
+        userDao.insert(user);
 
-        final var actual = userDao.findById(connection, 2L);
-
-        assertThat(actual.getAccount()).isEqualTo(account);
+        final var actual = userDao.findByAccount("insert-gugu");
+        assertThat(actual).isNotNull();
     }
 
     @Test
     void update() {
         final var newPassword = "password99";
-        final var user = userDao.findById(connection, 1L);
+        final var user = userDao.findById(1L);
         user.changePassword(newPassword);
 
-        userDao.update(connection, user);
+        userDao.update(user);
 
-        final var actual = userDao.findById(connection, 1L);
+        final var actual = userDao.findById(1L);
 
         assertThat(actual.getPassword()).isEqualTo(newPassword);
     }

--- a/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-class UserServiceTest {
+class AppUserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
@@ -28,13 +28,13 @@ class UserServiceTest {
 
         DatabasePopulatorUtils.execute(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
-        userDao.insert(dataSource.getConnection(), user);
+        userDao.insert( user);
     }
 
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(dataSource, userDao, userHistoryDao);
+        final var userService = new AppUserService(dataSource, userDao, userHistoryDao);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -49,7 +49,7 @@ class UserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new UserService(dataSource, userDao, userHistoryDao);
+        final var userService = new AppUserService(dataSource, userDao, userHistoryDao);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -13,7 +13,7 @@ public class MockUserHistoryDao extends UserHistoryDao {
     }
 
     @Override
-    public void log(final Connection connection, final UserHistory userHistory) {
+    public void log(final UserHistory userHistory) {
         throw new JdbcTemplateException("공습 경보!!!") {
             @Override
             public String getMessage() {

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -14,27 +14,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-class AppUserServiceTest {
+class UserServiceTest {
 
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
     private DataSource dataSource;
 
     @BeforeEach
-    void setUp() throws SQLException {
+    void setUp() {
         this.dataSource = DataSourceConfig.getInstance();
         this.jdbcTemplate = new JdbcTemplate(dataSource);
         this.userDao = new UserDao(jdbcTemplate);
 
         DatabasePopulatorUtils.execute(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
-        userDao.insert( user);
+        userDao.insert(user);
     }
 
     @Test
     void testChangePassword() {
         final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
-        final var userService = new AppUserService(dataSource, userDao, userHistoryDao);
+        final var userService = new AppUserService(userDao, userHistoryDao);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -49,7 +49,10 @@ class AppUserServiceTest {
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
-        final var userService = new AppUserService(dataSource, userDao, userHistoryDao);
+        // 애플리케이션 서비스
+        final var appUserService = new AppUserService(userDao, userHistoryDao);
+        // 트랜잭션 서비스 추상화
+        final var userService = new TxUserService(appUserService, dataSource);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
@@ -7,7 +7,6 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-// 4단계 미션에서 사용할 것
 public abstract class DataSourceUtils {
 
     private DataSourceUtils() {}
@@ -29,6 +28,7 @@ public abstract class DataSourceUtils {
 
     public static void releaseConnection(Connection connection, DataSource dataSource) {
         try {
+            TransactionSynchronizationManager.unbindResource(dataSource);
             connection.close();
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to close JDBC Connection");

--- a/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
@@ -11,7 +11,7 @@ public abstract class DataSourceUtils {
 
     private DataSourceUtils() {}
 
-    public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
+    public static Connection getConnection(final DataSource dataSource) throws CannotGetJdbcConnectionException {
         Connection connection = TransactionSynchronizationManager.getResource(dataSource);
         if (connection != null) {
             return connection;
@@ -26,7 +26,7 @@ public abstract class DataSourceUtils {
         }
     }
 
-    public static void releaseConnection(Connection connection, DataSource dataSource) {
+    public static void releaseConnection(final Connection connection, final DataSource dataSource) {
         try {
             TransactionSynchronizationManager.unbindResource(dataSource);
             connection.close();

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
@@ -16,15 +16,15 @@ public abstract class TransactionSynchronizationManager {
 
     private TransactionSynchronizationManager() {}
 
-    public static Connection getResource(DataSource key) {
+    public static Connection getResource(final DataSource key) {
         return resources.get().get(key);
     }
 
-    public static void bindResource(DataSource key, Connection value) {
+    public static void bindResource(final DataSource key, final Connection value) {
         resources.get().put(key, value);
     }
 
-    public static Connection unbindResource(DataSource key) {
+    public static Connection unbindResource(final DataSource key) {
         return resources.get().remove(key);
     }
 }

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
@@ -1,20 +1,16 @@
 package org.springframework.transaction.support;
 
-import java.util.HashMap;
-import javax.sql.DataSource;
 import java.sql.Connection;
+import java.util.HashMap;
 import java.util.Map;
+import javax.sql.DataSource;
 
 public abstract class TransactionSynchronizationManager {
 
-    private static final ThreadLocal<Map<DataSource, Connection>> resources;
+    private static final ThreadLocal<Map<DataSource, Connection>> resources = ThreadLocal.withInitial(HashMap::new);
 
-    static {
-        resources = new ThreadLocal<>();
-        resources.set(new HashMap<>());
+    private TransactionSynchronizationManager() {
     }
-
-    private TransactionSynchronizationManager() {}
 
     public static Connection getResource(final DataSource key) {
         return resources.get().get(key);

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
@@ -1,23 +1,30 @@
 package org.springframework.transaction.support;
 
+import java.util.HashMap;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.util.Map;
 
 public abstract class TransactionSynchronizationManager {
 
-    private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
+    private static final ThreadLocal<Map<DataSource, Connection>> resources;
+
+    static {
+        resources = new ThreadLocal<>();
+        resources.set(new HashMap<>());
+    }
 
     private TransactionSynchronizationManager() {}
 
     public static Connection getResource(DataSource key) {
-        return null;
+        return resources.get().get(key);
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        resources.get().put(key, value);
     }
 
     public static Connection unbindResource(DataSource key) {
-        return null;
+        return resources.get().remove(key);
     }
 }

--- a/jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTest.java
@@ -98,7 +98,7 @@ class JdbcTemplateTest {
     }
 
     @Test
-    void connection을_전달하지_않는_경우_내부에서_트랜잭션이_설정된다() throws SQLException {
+    void JdbcTemplate에서_트랜잭션을_관리하지_않는다() throws SQLException {
         DataSource mockDataSource = mock(DataSource.class);
         Connection mockConnection = mock(Connection.class);
         JdbcTemplate mockJdbcTemplate = new JdbcTemplate(mockDataSource);
@@ -109,50 +109,6 @@ class JdbcTemplateTest {
                 .thenReturn(TestDataSourceConfig.getInstance().getConnection().prepareStatement(sql));
 
         mockJdbcTemplate.find(sql,
-                (rs) -> new TestMember(
-                        rs.getLong("id"),
-                        rs.getString("name")
-                ));
-
-        assertAll(
-                () -> verify(mockConnection, times(1)).setAutoCommit(false),
-                () -> verify(mockConnection, times(1)).setAutoCommit(true),
-                () -> verify(mockConnection, never()).rollback()
-        );
-    }
-
-    @Test
-    void connection을_전달하지_않는_경우_예외가_발생하면_롤백이_호출된다() throws SQLException {
-        DataSource mockDataSource = mock(DataSource.class);
-        Connection mockConnection = mock(Connection.class);
-        JdbcTemplate mockJdbcTemplate = new JdbcTemplate(mockDataSource);
-
-        String sql = "insert into member (name) values ('kong');";
-        when(mockDataSource.getConnection()).thenReturn(mockConnection);
-        when(mockConnection.prepareStatement(sql)).thenThrow(new DatabaseAccessException("공습 경보! 공습 경보!"));
-
-        assertThatThrownBy(() -> mockJdbcTemplate.execute(sql))
-                .isInstanceOf(JdbcTemplateException.class);
-
-        assertAll(
-                () -> verify(mockConnection, times(1)).setAutoCommit(false),
-                () -> verify(mockConnection, times(1)).setAutoCommit(true),
-                () -> verify(mockConnection, times(1)).rollback()
-        );
-    }
-
-    @Test
-    void connection을_전달하는_경우_트랜잭션이_걸리지_않고_autocommit이_유지된다() throws SQLException {
-        DataSource mockDataSource = mock(DataSource.class);
-        Connection mockConnection = mock(Connection.class);
-        JdbcTemplate mockJdbcTemplate = new JdbcTemplate(mockDataSource);
-
-        String sql = "select id, name from member where name = '콩하나';";
-        when(mockConnection.prepareStatement(sql))
-                .thenReturn(TestDataSourceConfig.getInstance().getConnection().prepareStatement(sql));
-
-        mockJdbcTemplate.find(mockConnection,
-                sql,
                 (rs) -> new TestMember(
                         rs.getLong("id"),
                         rs.getString("name")

--- a/jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTest.java
+++ b/jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTest.java
@@ -1,7 +1,6 @@
 package org.springframework.jdbc.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -17,9 +16,9 @@ import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.TestDataSourceConfig;
-import org.springframework.jdbc.core.JdbcTemplateException.DatabaseAccessException;
 import org.springframework.jdbc.core.JdbcTemplateException.MoreDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplateException.NoDataAccessException;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 class JdbcTemplateTest {
 
@@ -118,6 +117,52 @@ class JdbcTemplateTest {
                 () -> verify(mockConnection, never()).setAutoCommit(false),
                 () -> verify(mockConnection, never()).setAutoCommit(true),
                 () -> verify(mockConnection, never()).rollback()
+        );
+    }
+
+    @Test
+    void 외부에서_connection을_얻지_않으면_JdbcTemplate에서_connection을_close한다() throws SQLException {
+        DataSource mockDataSource = mock(DataSource.class);
+        Connection mockConnection = mock(Connection.class);
+        JdbcTemplate mockJdbcTemplate = new JdbcTemplate(mockDataSource);
+
+        String sql = "select id, name from member where name = '콩하나';";
+        when(mockDataSource.getConnection()).thenReturn(mockConnection);
+        when(mockConnection.prepareStatement(sql))
+                .thenReturn(TestDataSourceConfig.getInstance().getConnection().prepareStatement(sql));
+
+        mockJdbcTemplate.find(sql,
+                (rs) -> new TestMember(
+                        rs.getLong("id"),
+                        rs.getString("name")
+                ));
+
+        assertAll(
+                () -> verify(mockDataSource, times(1)).getConnection(),
+                () -> verify(mockConnection, times(1)).close()
+        );
+    }
+
+    @Test
+    void 외부에서_connection을_얻으면_JdbcTemplate에서_connection을_close하지_않는다() throws SQLException {
+        DataSource mockDataSource = mock(DataSource.class);
+        Connection mockConnection = mock(Connection.class);
+        TransactionSynchronizationManager.bindResource(mockDataSource, mockConnection);
+        JdbcTemplate mockJdbcTemplate = new JdbcTemplate(mockDataSource);
+
+        String sql = "select id, name from member where name = '콩하나';";
+        when(mockConnection.prepareStatement(sql))
+                .thenReturn(TestDataSourceConfig.getInstance().getConnection().prepareStatement(sql));
+
+        mockJdbcTemplate.find(sql,
+                (rs) -> new TestMember(
+                        rs.getLong("id"),
+                        rs.getString("name")
+                ));
+        
+        assertAll(
+                () -> verify(mockDataSource, never()).getConnection(),
+                () -> verify(mockConnection, never()).close()
         );
     }
 }

--- a/jdbc/src/test/java/org/springframework/transaction/support/TransactionSynchronizationManagerTest.java
+++ b/jdbc/src/test/java/org/springframework/transaction/support/TransactionSynchronizationManagerTest.java
@@ -1,0 +1,31 @@
+package org.springframework.transaction.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.TestDataSourceConfig;
+
+class TransactionSynchronizationManagerTest {
+
+    @Test
+    void 쓰레드별로_동일한_데이터소스를_가져도_서로_다른_리소스를_가진다() throws InterruptedException {
+        DataSource dataSource = TestDataSourceConfig.getInstance();
+        new Thread(() -> {
+            try {
+                TransactionSynchronizationManager.bindResource(dataSource, dataSource.getConnection()); // 한 쓰레드에서 connection 바인딩
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+            Connection resource = TransactionSynchronizationManager.getResource(dataSource);
+            assertThat(resource).isNotNull();
+        }).start();
+
+        Thread.sleep(500);
+        assertThatThrownBy(() -> TransactionSynchronizationManager.getResource(dataSource)) // 동일한 키 값으로 조회하더라도 쓰레드가 달라서 NPE 발생
+                .isInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
안녕하세요 주드! 콩하나입니다.
마지막 미션이네용

원래 어제 다 마무리해서 제출까지 하려고 했으나,
어제 갑작스러운 인텔리제이 라이센스 만료 이슈로 인해...
갖가지 방법을 찾아보다가 결국 트라이얼 모드로 30일 무료 이용해서 하고 있네요.
아직 학교 졸업 안했는데 인증이 안된대요.. ㅠㅠ 
깃허브로 인증받는 것도 위와 동일한 이슈로 안되고... 이클립스를 하려하니까 생산성도 떨어지고 빌드가 안돼서
돌고 돌아서 인텔리제이네요 ㅋㅋㅋㅋ

아무튼 그래도 오늘 무사히 미션 완료해서 제출합니다.
이번에도 특별히 집중했던 부분을 공유드릴게요.

## 집중했던 부분
### ~~ `jdbcTemplate`보단 Service의 트랜잭션 추상화~~...를 하려 했으나 어쩔 수 없이 JdbcTemplate의 수정... ㅠㅠ
원래는 다음과 같이 생각했었습니다.
```
커넥션을 직접 생성하는 대신, `DataSourceUtils`를 사용해 대신 커넥션을 생성해주는 기능을 만들다보니
JdbcTemplate 클래스도 수정을 할지 말지 고민이 많았습니다.
JdbcTemplate에서 `커넥션을 전달받는 메소드는 트랜잭션 관리 책임을 외부`에 맡기고 있지만,
`커넥션을 전달받지 않는 메소드는 트랜잭션 관리를 내부`에서 하고 있기 때문이죠.

그래서 이 부분을 통일해주는게 좋을까말까 고민하다가 일단 한번 해보자!라는 마음으로 JdbcTemplate을 수정했었는데요.
결국 다시 롤백하고, JdbcTemplate은 건들지 않기로 결정했습니다. 그 이유는
1. 4단계 미션은 트랜잭션 추상화에 목표를 둔다. 현재 JdbcTemplate을 관리하는 것은 미션의 목표에는 다소 동떨어져있다
2. 라이브러리는 ocp원칙을 잘 지켜야한다. 그리고 저는 이 원칙을 지키려고 현재의 코드 구조가 나왔다고 판단했습니다.
3. 외부에서 connection을 받지 않고, JdbcTemplate 내부에서 `DataSourceUtils`을 사용해 커넥션을 받는 구조가 좋은 구조인지 잘 모르겠다. 커넥션을 받는 해당 정적 유틸리티가 너무 다양한 곳에서 사용돼서 문제가 있다고 판단했습니다.

결국 이러한 이유들로 JdbcTemplate은 건들지 않고 Service의 트랜잭션 추상화에만 집중하기로 결정했습니다.
이 때문에 `service -> dao -> jdbcTemplate으로 connection이 연달아 전달`되고 있지만,
이렇게 전달되는 것을 끊기 위해 정적 유틸리티에 의존하는 것이 더 위험하다고 생각해 나쁘지 않다고 생각했어요.
이에 대해 주드의 의견도 궁금하네요 😄
```

하지만 결국 JdbcTemplate에서 connection을 전달받는 기능을 모두 제거했습니다.
1. 2단계 미션을 진행하면서 dao로 connection을 전달해주는 것이 불가능해졌고,
2. 다시 생각해보니 `DataSourceUtils`라는 헬퍼 클래스가 라이브러리에서 제공해주는 클래스인만큼 JdbcTemplate을 사용하는 방법으로 숙지해두면 괜찮겠다는 생각이 들었어요. 이를 보강하기 위해 스프링에서는 프록시를 만들어서 트랜잭션을 따로 관리해주고 있기도 하니까요.

그래도 외부에서 connection을 직접 해제하지 않으면 jdbcTemplate에서는 이를 해제할 수 있는 방법이 없다는게 아쉽네요. 

### 참고하면 좋을 사항
### DataSourceUtils.releaseConnection() 메소드 내에 TransactionSynchronizationManager.unbindResource() 추가
예시에서는 둘을 분리해서 사용해주고 있는데, 
아무리 생각해도 둘을 하나로 묶어서 이를 사용하는 측에서는 `DataSourceUtils만 사용`하도록 좋아보여서 이렇게 구현했습니다.

왜 둘을 분리했을까요?
그냥 예시일 뿐인 걸까요? 
주드의 생각이 궁금합니다.