### PR TITLE
[JDBC 라이브러리 구현하기 - 4단계] 도이(유도영) 미션 제출합니다. 

### DIFF
--- a/app/src/main/java/com/techcourse/dao/UserDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserDao.java
@@ -2,10 +2,8 @@ package com.techcourse.dao;
 
 import com.techcourse.domain.User;
 import java.util.List;
-import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 
 public class UserDao {
 
@@ -17,18 +15,15 @@ public class UserDao {
                     resultSet.getString(4)
             );
 
-    private final DataSource dataSource;
     private final JdbcTemplate jdbcTemplate;
 
-    public UserDao(final DataSource dataSource, final JdbcTemplate jdbcTemplate) {
-        this.dataSource = dataSource;
+    public UserDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 
     public void insert(final User user) {
         final var sql = "insert into users (account, password, email) values (?, ?, ?)";
         jdbcTemplate.executeUpdate(
-                DataSourceUtils.getConnection(dataSource),
                 sql,
                 user.getAccount(),
                 user.getPassword(),
@@ -39,7 +34,6 @@ public class UserDao {
     public void update(final User user) {
         final var sql = "update users set account = ?, password = ?, email = ? where id = ?";
         jdbcTemplate.executeUpdate(
-                DataSourceUtils.getConnection(dataSource),
                 sql,
                 user.getAccount(),
                 user.getPassword(),
@@ -50,17 +44,16 @@ public class UserDao {
 
     public List<User> findAll() {
         final var sql = "select id, account, password, email from users";
-        return jdbcTemplate.executeQueryForList(DataSourceUtils.getConnection(dataSource), sql, USER_ROW_MAPPER);
+        return jdbcTemplate.executeQueryForList(sql, USER_ROW_MAPPER);
     }
 
     public User findById(final Long id) {
         final var sql = "select id, account, password, email from users where id = ?";
-        return jdbcTemplate.executeQueryForObject(DataSourceUtils.getConnection(dataSource), sql, USER_ROW_MAPPER, id);
+        return jdbcTemplate.executeQueryForObject(sql, USER_ROW_MAPPER, id);
     }
 
     public User findByAccount(final String account) {
         final var sql = "select id, account, password, email from users where account = ?";
-        return jdbcTemplate.executeQueryForObject(DataSourceUtils.getConnection(dataSource), sql, USER_ROW_MAPPER,
-                account);
+        return jdbcTemplate.executeQueryForObject(sql, USER_ROW_MAPPER, account);
     }
 }

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,21 +1,17 @@
 package com.techcourse.dao;
 
 import com.techcourse.domain.UserHistory;
-import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceUtils;
 
 public class UserHistoryDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
-    private final DataSource dataSource;
     private final JdbcTemplate jdbcTemplate;
 
-    public UserHistoryDao(final DataSource dataSource, final JdbcTemplate jdbcTemplate) {
-        this.dataSource = dataSource;
+    public UserHistoryDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 
@@ -23,7 +19,6 @@ public class UserHistoryDao {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
         log.info("query: {}", sql);
         jdbcTemplate.executeUpdate(
-                DataSourceUtils.getConnection(dataSource),
                 sql,
                 userHistory.getUserId(),
                 userHistory.getAccount(),

--- a/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
+++ b/app/src/main/java/com/techcourse/dao/UserHistoryDao.java
@@ -1,45 +1,29 @@
 package com.techcourse.dao;
 
 import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.TransactionManager;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 
 public class UserHistoryDao {
 
     private static final Logger log = LoggerFactory.getLogger(UserHistoryDao.class);
 
-    private final TransactionManager transactionManager;
+    private final DataSource dataSource;
     private final JdbcTemplate jdbcTemplate;
 
-    public UserHistoryDao(final TransactionManager transactionManager, final JdbcTemplate jdbcTemplate) {
-        this.transactionManager = transactionManager;
+    public UserHistoryDao(final DataSource dataSource, final JdbcTemplate jdbcTemplate) {
+        this.dataSource = dataSource;
         this.jdbcTemplate = jdbcTemplate;
     }
 
     public void log(final UserHistory userHistory) {
         final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
         log.info("query: {}", sql);
-        transactionManager.save(
-                (connection, entity) -> jdbcTemplate.executeUpdate(
-                        connection,
-                        sql,
-                        userHistory.getUserId(),
-                        userHistory.getAccount(),
-                        userHistory.getPassword(),
-                        userHistory.getEmail(),
-                        userHistory.getCreatedAt(),
-                        userHistory.getCreateBy()
-                ), userHistory);
-    }
-
-    public void log(final Connection connection, final UserHistory userHistory) {
-        final var sql = "insert into user_history (user_id, account, password, email, created_at, created_by) values (?, ?, ?, ?, ?, ?)";
-        log.info("query: {}", sql);
         jdbcTemplate.executeUpdate(
-                connection,
+                DataSourceUtils.getConnection(dataSource),
                 sql,
                 userHistory.getUserId(),
                 userHistory.getAccount(),
@@ -49,4 +33,5 @@ public class UserHistoryDao {
                 userHistory.getCreateBy()
         );
     }
+
 }

--- a/app/src/main/java/com/techcourse/service/AppUserService.java
+++ b/app/src/main/java/com/techcourse/service/AppUserService.java
@@ -1,0 +1,37 @@
+package com.techcourse.service;
+
+import com.techcourse.dao.UserDao;
+import com.techcourse.dao.UserHistoryDao;
+import com.techcourse.domain.User;
+import com.techcourse.domain.UserHistory;
+
+public class AppUserService implements UserService {
+
+    private final UserDao userDao;
+    private final UserHistoryDao userHistoryDao;
+
+    public AppUserService(
+            final UserDao userDao,
+            final UserHistoryDao userHistoryDao) {
+        this.userDao = userDao;
+        this.userHistoryDao = userHistoryDao;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userDao.findById(id);
+    }
+
+    @Override
+    public void insert(final User user) {
+        userDao.insert(user);
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String createBy) {
+        final var user = findById(id);
+        user.changePassword(newPassword);
+        userDao.update(user);
+        userHistoryDao.log(new UserHistory(user, createBy));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,0 +1,30 @@
+package com.techcourse.service;
+
+import com.techcourse.domain.User;
+import org.springframework.jdbc.core.TransactionManager;
+
+public class TxUserService implements UserService {
+
+    private final TransactionManager transactionManager;
+    private final AppUserService userService;
+
+    public TxUserService(final TransactionManager transactionManager, final AppUserService userService) {
+        this.transactionManager = transactionManager;
+        this.userService = userService;
+    }
+
+    @Override
+    public User findById(final long id) {
+        return userService.findById(id);
+    }
+
+    @Override
+    public void insert(final User user) {
+        userService.insert(user);
+    }
+
+    @Override
+    public void changePassword(final long id, final String newPassword, final String creatBy) {
+        transactionManager.execute(() -> userService.changePassword(id, newPassword, creatBy));
+    }
+}

--- a/app/src/main/java/com/techcourse/service/TxUserService.java
+++ b/app/src/main/java/com/techcourse/service/TxUserService.java
@@ -1,15 +1,15 @@
 package com.techcourse.service;
 
 import com.techcourse.domain.User;
-import org.springframework.jdbc.core.TransactionManager;
+import org.springframework.jdbc.core.TransactionExecutor;
 
 public class TxUserService implements UserService {
 
-    private final TransactionManager transactionManager;
+    private final TransactionExecutor transactionExecutor;
     private final AppUserService userService;
 
-    public TxUserService(final TransactionManager transactionManager, final AppUserService userService) {
-        this.transactionManager = transactionManager;
+    public TxUserService(final TransactionExecutor transactionExecutor, final AppUserService userService) {
+        this.transactionExecutor = transactionExecutor;
         this.userService = userService;
     }
 
@@ -25,6 +25,6 @@ public class TxUserService implements UserService {
 
     @Override
     public void changePassword(final long id, final String newPassword, final String creatBy) {
-        transactionManager.execute(() -> userService.changePassword(id, newPassword, creatBy));
+        transactionExecutor.execute(() -> userService.changePassword(id, newPassword, creatBy));
     }
 }

--- a/app/src/main/java/com/techcourse/service/UserService.java
+++ b/app/src/main/java/com/techcourse/service/UserService.java
@@ -1,42 +1,13 @@
 package com.techcourse.service;
 
-import com.techcourse.dao.UserDao;
-import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
-import com.techcourse.domain.UserHistory;
-import org.springframework.jdbc.core.TransactionManager;
 
-public class UserService {
+public interface UserService {
 
-    private final TransactionManager transactionManager;
-    private final UserDao userDao;
-    private final UserHistoryDao userHistoryDao;
+    User findById(final long id);
 
-    public UserService(
-            final TransactionManager transactionManager,
-            final UserDao userDao,
-            final UserHistoryDao userHistoryDao) {
-        this.transactionManager = transactionManager;
-        this.userDao = userDao;
-        this.userHistoryDao = userHistoryDao;
-    }
+    void insert(User user);
 
-    public User findById(final long id) {
-        return userDao.findById(id);
-    }
-
-    public void insert(final User user) {
-        userDao.insert(user);
-    }
-
-    public void changePassword(final long id, final String newPassword, final String createBy) {
-        final var user = findById(id);
-        user.changePassword(newPassword);
-        transactionManager.save(
-                (connection, entity) -> {
-                    userDao.update(connection, entity);
-                    userHistoryDao.log(connection, new UserHistory(entity, createBy));
-                },
-                user);
-    }
+    void changePassword(final long id, final String newPassword, final String creatBy);
+    
 }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -17,7 +17,7 @@ class UserDaoTest {
     void setup() {
         final var dataSource = DataSourceConfig.getInstance();
         DatabasePopulatorUtils.execute(dataSource);
-        userDao = new UserDao(dataSource, new JdbcTemplate());
+        userDao = new UserDao(new JdbcTemplate(dataSource));
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -8,7 +8,6 @@ import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.TransactionManager;
 
 class UserDaoTest {
 
@@ -16,9 +15,9 @@ class UserDaoTest {
 
     @BeforeEach
     void setup() {
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
-        userDao = new UserDao(new TransactionManager(DataSourceConfig.getInstance()),
-                new JdbcTemplate());
+        final var dataSource = DataSourceConfig.getInstance();
+        DatabasePopulatorUtils.execute(dataSource);
+        userDao = new UserDao(dataSource, new JdbcTemplate());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }

--- a/app/src/test/java/com/techcourse/dao/UserDaoTest.java
+++ b/app/src/test/java/com/techcourse/dao/UserDaoTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.techcourse.config.DataSourceConfig;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import com.techcourse.support.jdbc.init.PooledDataSourceConnectionManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -18,7 +17,8 @@ class UserDaoTest {
     @BeforeEach
     void setup() {
         DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
-        userDao = new UserDao(new TransactionManager(new PooledDataSourceConnectionManager()), new JdbcTemplate());
+        userDao = new UserDao(new TransactionManager(DataSourceConfig.getInstance()),
+                new JdbcTemplate());
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }

--- a/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
@@ -8,7 +8,6 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
@@ -17,17 +16,16 @@ import org.springframework.jdbc.core.TransactionExecutor;
 
 class AppUserServiceTest {
 
-    private DataSource dataSource;
     private TransactionExecutor transactionExecutor;
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
 
     @BeforeEach
     void setUp() {
-        this.dataSource = DataSourceConfig.getInstance();
+        final var dataSource = DataSourceConfig.getInstance();
         this.transactionExecutor = new TransactionExecutor(dataSource);
-        this.jdbcTemplate = new JdbcTemplate();
-        this.userDao = new UserDao(dataSource, jdbcTemplate);
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.userDao = new UserDao(jdbcTemplate);
 
         DatabasePopulatorUtils.execute(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
@@ -36,7 +34,7 @@ class AppUserServiceTest {
 
     @Test
     void testChangePassword() {
-        final var userHistoryDao = new UserHistoryDao(dataSource, jdbcTemplate);
+        final var userHistoryDao = new UserHistoryDao(jdbcTemplate);
         final var userService = new AppUserService(userDao, userHistoryDao);
 
         final var newPassword = "qqqqq";
@@ -51,7 +49,7 @@ class AppUserServiceTest {
     @Test
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
-        final var userHistoryDao = new MockUserHistoryDao(dataSource, jdbcTemplate);
+        final var userHistoryDao = new MockUserHistoryDao(jdbcTemplate);
         final var appUserService = new AppUserService(userDao, userHistoryDao);
         final var userService = new TxUserService(transactionExecutor, appUserService);
 

--- a/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
@@ -8,33 +8,36 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.TransactionManager;
 
-class UserServiceTest {
+class AppUserServiceTest {
 
+    private DataSource dataSource;
     private TransactionManager transactionManager;
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
 
     @BeforeEach
     void setUp() {
-        this.transactionManager = new TransactionManager(DataSourceConfig.getInstance());
+        this.dataSource = DataSourceConfig.getInstance();
+        this.transactionManager = new TransactionManager(dataSource);
         this.jdbcTemplate = new JdbcTemplate();
-        this.userDao = new UserDao(transactionManager, jdbcTemplate);
+        this.userDao = new UserDao(dataSource, jdbcTemplate);
 
-        DatabasePopulatorUtils.execute(DataSourceConfig.getInstance());
+        DatabasePopulatorUtils.execute(dataSource);
         final var user = new User("gugu", "password", "hkkang@woowahan.com");
         userDao.insert(user);
     }
 
     @Test
     void testChangePassword() {
-        final var userHistoryDao = new UserHistoryDao(transactionManager, jdbcTemplate);
-        final var userService = new UserService(transactionManager, userDao, userHistoryDao);
+        final var userHistoryDao = new UserHistoryDao(dataSource, jdbcTemplate);
+        final var userService = new AppUserService(userDao, userHistoryDao);
 
         final var newPassword = "qqqqq";
         final var createBy = "gugu";
@@ -48,8 +51,9 @@ class UserServiceTest {
     @Test
     void testTransactionRollback() {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
-        final var userHistoryDao = new MockUserHistoryDao(transactionManager, jdbcTemplate);
-        final var userService = new UserService(transactionManager, userDao, userHistoryDao);
+        final var userHistoryDao = new MockUserHistoryDao(dataSource, jdbcTemplate);
+        final var appUserService = new AppUserService(userDao, userHistoryDao);
+        final var userService = new TxUserService(transactionManager, appUserService);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/AppUserServiceTest.java
@@ -13,19 +13,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.TransactionManager;
+import org.springframework.jdbc.core.TransactionExecutor;
 
 class AppUserServiceTest {
 
     private DataSource dataSource;
-    private TransactionManager transactionManager;
+    private TransactionExecutor transactionExecutor;
     private JdbcTemplate jdbcTemplate;
     private UserDao userDao;
 
     @BeforeEach
     void setUp() {
         this.dataSource = DataSourceConfig.getInstance();
-        this.transactionManager = new TransactionManager(dataSource);
+        this.transactionExecutor = new TransactionExecutor(dataSource);
         this.jdbcTemplate = new JdbcTemplate();
         this.userDao = new UserDao(dataSource, jdbcTemplate);
 
@@ -53,7 +53,7 @@ class AppUserServiceTest {
         // 트랜잭션 롤백 테스트를 위해 mock으로 교체
         final var userHistoryDao = new MockUserHistoryDao(dataSource, jdbcTemplate);
         final var appUserService = new AppUserService(userDao, userHistoryDao);
-        final var userService = new TxUserService(transactionManager, appUserService);
+        final var userService = new TxUserService(transactionExecutor, appUserService);
 
         final var newPassword = "newPassword";
         final var createBy = "gugu";

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -2,14 +2,13 @@ package com.techcourse.service;
 
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
-import javax.sql.DataSource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 
-    public MockUserHistoryDao(final DataSource dataSource, final JdbcTemplate jdbcTemplate) {
-        super(dataSource, jdbcTemplate);
+    public MockUserHistoryDao(final JdbcTemplate jdbcTemplate) {
+        super(jdbcTemplate);
     }
 
     @Override

--- a/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
+++ b/app/src/test/java/com/techcourse/service/MockUserHistoryDao.java
@@ -2,19 +2,18 @@ package com.techcourse.service;
 
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.UserHistory;
-import java.sql.Connection;
+import javax.sql.DataSource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.TransactionManager;
 
 public class MockUserHistoryDao extends UserHistoryDao {
 
-    public MockUserHistoryDao(final TransactionManager transactionManager, final JdbcTemplate jdbcTemplate) {
-        super(transactionManager, jdbcTemplate);
+    public MockUserHistoryDao(final DataSource dataSource, final JdbcTemplate jdbcTemplate) {
+        super(dataSource, jdbcTemplate);
     }
 
     @Override
-    public void log(final Connection connection, final UserHistory userHistory) {
+    public void log(final UserHistory userHistory) {
         throw new DataAccessException();
     }
 }

--- a/app/src/test/java/com/techcourse/service/UserServiceTest.java
+++ b/app/src/test/java/com/techcourse/service/UserServiceTest.java
@@ -8,7 +8,6 @@ import com.techcourse.dao.UserDao;
 import com.techcourse.dao.UserHistoryDao;
 import com.techcourse.domain.User;
 import com.techcourse.support.jdbc.init.DatabasePopulatorUtils;
-import com.techcourse.support.jdbc.init.PooledDataSourceConnectionManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
@@ -23,7 +22,7 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        this.transactionManager = new TransactionManager(new PooledDataSourceConnectionManager());
+        this.transactionManager = new TransactionManager(DataSourceConfig.getInstance());
         this.jdbcTemplate = new JdbcTemplate();
         this.userDao = new UserDao(transactionManager, jdbcTemplate);
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -15,8 +15,7 @@ public class JdbcTemplate {
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
 
     public int executeUpdate(final Connection connection, final String query, final Object... parameters) {
-        PreparedStatementCallback<Integer> preparedStatementCallback = PreparedStatement::executeUpdate;
-        return execute(connection, query, preparedStatementCallback, parameters);
+        return execute(connection, query, PreparedStatement::executeUpdate, parameters);
     }
 
     public <T> T executeQueryForObject(
@@ -41,15 +40,13 @@ public class JdbcTemplate {
             final RowMapper<T> rowMapper,
             final Object... parameters
     ) {
-        final ResultSetExtractor<List<T>> resultSetExtractor = resultSet -> {
+        return executeQuery(connection, query, resultSet -> {
             final List<T> results = new ArrayList<>();
             while (resultSet.next()) {
                 results.add(rowMapper.mapRow(resultSet));
             }
             return results;
-        };
-
-        return executeQuery(connection, query, resultSetExtractor, parameters);
+        }, parameters);
     }
 
     public <T> T executeQuery(

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1,30 +1,36 @@
 package org.springframework.jdbc.core;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.SqlQueryException;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 
 public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
 
-    public int executeUpdate(final Connection connection, final String query, final Object... parameters) {
-        return execute(connection, query, PreparedStatement::executeUpdate, parameters);
+    private final DataSource dataSource;
+
+    public JdbcTemplate(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public int executeUpdate(final String query, final Object... parameters) {
+        return execute(query, PreparedStatement::executeUpdate, parameters);
     }
 
     public <T> T executeQueryForObject(
-            final Connection connection,
             final String query,
             final RowMapper<T> rowMapper,
             final Object... parameters
     ) {
-        final var results = executeQueryForList(connection, query, rowMapper, parameters);
+        final var results = executeQueryForList(query, rowMapper, parameters);
         if (results.isEmpty()) {
             return null;
         }
@@ -35,12 +41,11 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> executeQueryForList(
-            final Connection connection,
             final String query,
             final RowMapper<T> rowMapper,
             final Object... parameters
     ) {
-        return executeQuery(connection, query, resultSet -> {
+        return executeQuery(query, resultSet -> {
             final List<T> results = new ArrayList<>();
             while (resultSet.next()) {
                 results.add(rowMapper.mapRow(resultSet));
@@ -50,27 +55,23 @@ public class JdbcTemplate {
     }
 
     public <T> T executeQuery(
-            final Connection connection,
             final String query,
             final ResultSetExtractor<T> resultSetExtractor,
             final Object... parameters
     ) {
-        return execute(
-                connection,
-                query,
-                preparedStatement -> {
-                    try (final ResultSet resultSet = preparedStatement.executeQuery()) {
-                        return resultSetExtractor.extract(resultSet);
-                    }
-                }, parameters);
+        return execute(query, preparedStatement -> {
+            try (final ResultSet resultSet = preparedStatement.executeQuery()) {
+                return resultSetExtractor.extract(resultSet);
+            }
+        }, parameters);
     }
 
     private <T> T execute(
-            final Connection connection,
             final String query,
             final PreparedStatementCallback<T> callback,
             final Object... parameters
     ) {
+        final var connection = DataSourceUtils.getConnection(dataSource);
         try (final PreparedStatement preparedStatement = connection.prepareStatement(query)) {
             log.info("query: {}", query);
             setParameters(preparedStatement, parameters);
@@ -79,6 +80,8 @@ public class JdbcTemplate {
         } catch (SQLException exception) {
             throw new SqlQueryException(exception.getMessage(), query);
         }
+        // TODO TransactionExecutor를 거치지 않을 때도 connection을 닫고 unbind 해주어야한다.
+        // 하지만 논리적 트랜잭션으로 묶여있다면 여기서 해주면 안된다.
     }
 
     private void setParameters(final PreparedStatement preparedStatement, final Object... parameters)

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -71,8 +71,7 @@ public class JdbcTemplate {
             final PreparedStatementCallback<T> callback,
             final Object... parameters
     ) {
-        try (final Connection conn = connection;
-             final PreparedStatement preparedStatement = conn.prepareStatement(query)) {
+        try (final PreparedStatement preparedStatement = connection.prepareStatement(query)) {
             log.info("query: {}", query);
             setParameters(preparedStatement, parameters);
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -79,9 +79,9 @@ public class JdbcTemplate {
             return callback.doInConnection(preparedStatement);
         } catch (SQLException exception) {
             throw new SqlQueryException(exception.getMessage(), query);
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
         }
-        // TODO TransactionExecutor를 거치지 않을 때도 connection을 닫고 unbind 해주어야한다.
-        // 하지만 논리적 트랜잭션으로 묶여있다면 여기서 해주면 안된다.
     }
 
     private void setParameters(final PreparedStatement preparedStatement, final Object... parameters)

--- a/jdbc/src/main/java/org/springframework/jdbc/core/TransactionExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/TransactionExecutor.java
@@ -8,12 +8,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 
-public class TransactionManager {
+public class TransactionExecutor {
 
-    private final Logger log = LoggerFactory.getLogger(TransactionManager.class);
+    private final Logger log = LoggerFactory.getLogger(TransactionExecutor.class);
     private final DataSource dataSource;
 
-    public TransactionManager(final DataSource dataSource) {
+    public TransactionExecutor(final DataSource dataSource) {
         this.dataSource = dataSource;
     }
 

--- a/jdbc/src/main/java/org/springframework/jdbc/core/TransactionExecutor.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/TransactionExecutor.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 public class TransactionExecutor {
 
@@ -20,6 +21,7 @@ public class TransactionExecutor {
     public void execute(final Runnable runnable) {
         final var connection = DataSourceUtils.getConnection(dataSource);
         try {
+            TransactionSynchronizationManager.setActualTransactionActive(true);
             connection.setAutoCommit(false);
             runnable.run();
             connection.commit();
@@ -32,6 +34,7 @@ public class TransactionExecutor {
             }
         } finally {
             try {
+                TransactionSynchronizationManager.setActualTransactionActive(false);
                 connection.setAutoCommit(true);
                 DataSourceUtils.releaseConnection(connection, dataSource);
             } catch (SQLException ignored) {

--- a/jdbc/src/main/java/org/springframework/jdbc/core/TransactionManager.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/TransactionManager.java
@@ -1,10 +1,7 @@
 package org.springframework.jdbc.core;
 
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,38 +17,12 @@ public class TransactionManager {
         this.dataSource = dataSource;
     }
 
-    public <T> T save(final BiConsumer<Connection, T> consumer, final T entity) {
+    public void execute(final Runnable runnable) {
         final var connection = DataSourceUtils.getConnection(dataSource);
         try {
             connection.setAutoCommit(false);
-            consumer.accept(connection, entity);
+            runnable.run();
             connection.commit();
-            return entity;
-        } catch (Exception exception) {
-            try {
-                connection.rollback();
-                throw new DataAccessException(exception);
-            } catch (SQLException sqlException) {
-                throw new DataAccessException(sqlException);
-            }
-        } finally {
-            try {
-                connection.setAutoCommit(true);
-                DataSourceUtils.releaseConnection(connection, dataSource);
-            } catch (SQLException ignored) {
-                log.warn("fail to set auto commit true due to {}", ignored.getMessage());
-                log.warn(Arrays.toString(ignored.getStackTrace()));
-            }
-        }
-    }
-
-    public <T> T find(final BiFunction<Connection, Object[], T> function, Object... parameters) {
-        final var connection = DataSourceUtils.getConnection(dataSource);
-        try {
-            connection.setAutoCommit(false);
-            final var result = function.apply(connection, parameters);
-            connection.commit();
-            return result;
         } catch (Exception exception) {
             try {
                 connection.rollback();

--- a/jdbc/src/main/java/org/springframework/jdbc/core/TransactionManager.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/core/TransactionManager.java
@@ -5,22 +5,24 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 
 public class TransactionManager {
 
     private final Logger log = LoggerFactory.getLogger(TransactionManager.class);
-    private final ConnectionManager connectionManager;
+    private final DataSource dataSource;
 
-    public TransactionManager(final ConnectionManager connectionManager) {
-        this.connectionManager = connectionManager;
+    public TransactionManager(final DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
     public <T> T save(final BiConsumer<Connection, T> consumer, final T entity) {
-        final var connection = connectionManager.getConnection();
-        try (connection) {
+        final var connection = DataSourceUtils.getConnection(dataSource);
+        try {
             connection.setAutoCommit(false);
             consumer.accept(connection, entity);
             connection.commit();
@@ -35,6 +37,7 @@ public class TransactionManager {
         } finally {
             try {
                 connection.setAutoCommit(true);
+                DataSourceUtils.releaseConnection(connection, dataSource);
             } catch (SQLException ignored) {
                 log.warn("fail to set auto commit true due to {}", ignored.getMessage());
                 log.warn(Arrays.toString(ignored.getStackTrace()));
@@ -42,9 +45,9 @@ public class TransactionManager {
         }
     }
 
-    public <T> T find(final BiFunction<Connection, Object[], T> function, final Object... parameters) {
-        final var connection = connectionManager.getConnection();
-        try (connection) {
+    public <T> T find(final BiFunction<Connection, Object[], T> function, Object... parameters) {
+        final var connection = DataSourceUtils.getConnection(dataSource);
+        try {
             connection.setAutoCommit(false);
             final var result = function.apply(connection, parameters);
             connection.commit();
@@ -59,10 +62,12 @@ public class TransactionManager {
         } finally {
             try {
                 connection.setAutoCommit(true);
+                DataSourceUtils.releaseConnection(connection, dataSource);
             } catch (SQLException ignored) {
                 log.warn("fail to set auto commit true due to {}", ignored.getMessage());
                 log.warn(Arrays.toString(ignored.getStackTrace()));
             }
         }
     }
+
 }

--- a/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
@@ -28,7 +28,11 @@ public abstract class DataSourceUtils {
     }
 
     public static void releaseConnection(Connection connection, DataSource dataSource) {
-        try {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            return;
+        }
+
+        try (connection) {
             connection.close();
             TransactionSynchronizationManager.unbindResource(dataSource);
         } catch (SQLException ex) {

--- a/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
+++ b/jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceUtils.java
@@ -9,7 +9,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 // 4단계 미션에서 사용할 것
 public abstract class DataSourceUtils {
 
-    private DataSourceUtils() {}
+    private DataSourceUtils() {
+    }
 
     public static Connection getConnection(DataSource dataSource) throws CannotGetJdbcConnectionException {
         Connection connection = TransactionSynchronizationManager.getResource(dataSource);
@@ -29,6 +30,7 @@ public abstract class DataSourceUtils {
     public static void releaseConnection(Connection connection, DataSource dataSource) {
         try {
             connection.close();
+            TransactionSynchronizationManager.unbindResource(dataSource);
         } catch (SQLException ex) {
             throw new CannotGetJdbcConnectionException("Failed to close JDBC Connection");
         }

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
@@ -8,6 +8,7 @@ import javax.sql.DataSource;
 public abstract class TransactionSynchronizationManager {
 
     private static final ThreadLocal<Map<DataSource, Connection>> resources = ThreadLocal.withInitial(HashMap::new);
+    private static final ThreadLocal<Boolean> isActualTransactionActive = ThreadLocal.withInitial(() -> false);
 
     private TransactionSynchronizationManager() {
     }
@@ -28,4 +29,13 @@ public abstract class TransactionSynchronizationManager {
 
         return connection;
     }
+
+    public static void setActualTransactionActive(boolean active) {
+        isActualTransactionActive.set(active);
+    }
+
+    public static boolean isActualTransactionActive() {
+        return isActualTransactionActive.get();
+    }
+
 }

--- a/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
+++ b/jdbc/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
@@ -1,23 +1,31 @@
 package org.springframework.transaction.support;
 
 import java.sql.Connection;
+import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
 
 public abstract class TransactionSynchronizationManager {
 
-    private static final ThreadLocal<Map<DataSource, Connection>> resources = new ThreadLocal<>();
+    private static final ThreadLocal<Map<DataSource, Connection>> resources = ThreadLocal.withInitial(HashMap::new);
 
-    private TransactionSynchronizationManager() {}
+    private TransactionSynchronizationManager() {
+    }
 
     public static Connection getResource(DataSource key) {
-        return null;
+        final var connections = resources.get();
+        return connections.get(key);
     }
 
     public static void bindResource(DataSource key, Connection value) {
+        resources.set(Map.of(key, value));
     }
 
     public static Connection unbindResource(DataSource key) {
-        return null;
+        final var connections = resources.get();
+        final var connection = connections.get(key);
+        resources.remove();
+
+        return connection;
     }
 }


### PR DESCRIPTION
안녕하세요 에코!! 4단계로 돌아왔습니당  

이번 미션에서는 최대한 기존 코드를 유지하며 요구사항을 만족해보려고 했습니다.  

1. 트랜잭션 중첩 문제
첫번째 요구사항인 트랜잭션 동기화 적용의 경우,  제 코드에서는  
Service, DAO에서 모두 제가 만든 `TransactionExecutor`(이전 네이밍 `TransactionManager`)를 사용하고 있었기에
해당 클래스에서 DataSourceUtils 를 사용하도록 수정했습니다.

- 그런데 이 과정에서, 
`UserService.changePassword`와 같이 여러 개의 DAO 메서드를 호출하면 **DAO 단에서 계속해서 `unbindResource`를 다시 해주는** 문제가 발생했습니다. (그래서 같은 connection을 공유할 수 없음)  
그래서 DAO에서는 `TransactionExecutor`를 거치지 않고 JdbcTemplate을 호출하도록 수정했어요.  
그렇게 했더니, 원래 문제는 해결되었지만  
**별도의 트랜잭션을 지원하지 않고 JdbcTemplate을 바로 호출하는 경우 Connection을 닫아주지 못하는 문제**가 생겼습니다.  

2. 논리적 트랜잭션에 대한 상태 추가
그래서 이 부분은 **`TransactionSynchronizationManager`에 `isActualTransactionActive`이라는 상태를 추가**하는 것으로 해결했습니다.  
해당 내용은 실제 Spring [코드](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/reactive/TransactionSynchronizationManager.html)에 어떤 메서드가 있는지만 확인해보았는데요.  
저는 'ActualTransaction'이, 여러 트랜잭션을 묶어 실제로 활성화된 논리적 트랜잭션을 의미한다고 유추하고 진행했습니다.  
깊게 학습하지 못해 실제 쓰임새와 유사한지는 확실치 않습니다..ㅎㅎ  
`TransactionExecutor`로 논리적 트랜잭션을 생성할 때는 해당 상태를 true로 변경합니다.  
그리고 `DataUtils.releaseConnection` 메서드에서는 해당 상태가 false일 때만 Connection을 닫아줍니다. 
따라서 이를 통해 JdbcTemplate에서도 `DataUtils.releaseConnection` 메서드를 호출할 수 있게 됩니다. 

----

`TransactionExecutor`에서도 커밋, 롤백과 같은 기능들을 잘 분리하면 좋을 것 같은데  
시간 관계 상 먼저 리뷰 요청 드립니다! 리뷰 요청 후 더 고민해보겠습니당
너무 늦어지면 안될 것 같아, 다이어그램 없이 장황하게 설명드려 죄송합니다! ㅜㅜ  
의문 가는 점 있으면 편하게 질문 주세요 ㅎㅎ  
이번에도 잘 부탁드려요 🙇‍♀️

추가로 지난 요 질문 https://github.com/woowacourse/jwp-dashboard-jdbc/pull/463#discussion_r1349710805
에 대해서는 저도 같이 고민해보고 싶은데, 질문 주신 내용을 제가 잘 이해하지 못해서 추가 질문 달았습니다!  